### PR TITLE
chore: npm publish metadata

### DIFF
--- a/package.json
+++ b/package.json
@@ -8,7 +8,8 @@
   "scripts": {
     "build": "pnpm -r build",
     "test": "vitest run",
-    "test:watch": "vitest"
+    "test:watch": "vitest",
+    "prepublishOnly": "pnpm -r build && vitest run"
   },
   "devDependencies": {
     "tsup": "^8.0.0",

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,6 +1,7 @@
 {
   "name": "@agent-layer/core",
   "version": "0.1.0",
+  "description": "Core utilities for making web apps AI-agent-friendly — error envelopes, rate limiting, llms.txt, and discovery",
   "type": "module",
   "exports": {
     ".": {
@@ -13,8 +14,31 @@
   "types": "./dist/index.d.ts",
   "files": ["dist"],
   "scripts": {
-    "build": "tsup"
+    "build": "tsup",
+    "prepublishOnly": "pnpm build"
   },
+  "author": "Isaac Chang <chang.isaac97@gmail.com>",
+  "license": "MIT",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/lightlayer-dev/agent-layer-ts.git",
+    "directory": "packages/core"
+  },
+  "homepage": "https://company.lightlayer.dev",
+  "bugs": {
+    "url": "https://github.com/lightlayer-dev/agent-layer-ts/issues"
+  },
+  "keywords": [
+    "ai",
+    "agent",
+    "llm",
+    "middleware",
+    "agent-native",
+    "rate-limit",
+    "llms-txt",
+    "openapi",
+    "discovery"
+  ],
   "devDependencies": {
     "tsup": "^8.0.0",
     "typescript": "^5.4.0"

--- a/packages/express/package.json
+++ b/packages/express/package.json
@@ -1,6 +1,7 @@
 {
   "name": "@agent-layer/express",
   "version": "0.1.0",
+  "description": "Express middleware to make your API AI-agent-friendly — errors, rate limits, llms.txt, auth, meta, and discovery",
   "type": "module",
   "exports": {
     ".": {
@@ -11,12 +12,33 @@
   "main": "./dist/index.cjs",
   "module": "./dist/index.js",
   "types": "./dist/index.d.ts",
-  "files": [
-    "dist"
-  ],
+  "files": ["dist"],
   "scripts": {
-    "build": "tsup"
+    "build": "tsup",
+    "prepublishOnly": "pnpm build"
   },
+  "author": "Isaac Chang <chang.isaac97@gmail.com>",
+  "license": "MIT",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/lightlayer-dev/agent-layer-ts.git",
+    "directory": "packages/express"
+  },
+  "homepage": "https://company.lightlayer.dev",
+  "bugs": {
+    "url": "https://github.com/lightlayer-dev/agent-layer-ts/issues"
+  },
+  "keywords": [
+    "ai",
+    "agent",
+    "llm",
+    "express",
+    "middleware",
+    "agent-native",
+    "rate-limit",
+    "llms-txt",
+    "openapi"
+  ],
   "dependencies": {
     "@agent-layer/core": "workspace:*"
   },


### PR DESCRIPTION
Add metadata to both packages for npm publishing: description, author, license, repo, homepage, bugs, keywords, prepublishOnly scripts. Both packages build successfully.