### PR TITLE
feat: add @agent-layer/koa package

### DIFF
--- a/README.md
+++ b/README.md
@@ -138,6 +138,7 @@ Overall Score: 82%
 |---------|-------------|
 | `@agent-layer/core` | Framework-agnostic core logic |
 | `@agent-layer/express` | Express.js middleware |
+| `@agent-layer/koa` | Koa middleware |
 
 Coming soon: Fastify, Next.js, Hono, and a [Python package](https://github.com/LightLayer-dev/agent-layer-python) for FastAPI/Django/Flask.
 

--- a/packages/koa/package.json
+++ b/packages/koa/package.json
@@ -1,0 +1,59 @@
+{
+  "name": "@agent-layer/koa",
+  "version": "0.1.0",
+  "description": "Koa middleware to make your API AI-agent-friendly — errors, rate limits, llms.txt, auth, meta, and discovery",
+  "type": "module",
+  "exports": {
+    ".": {
+      "import": "./dist/index.js",
+      "require": "./dist/index.cjs"
+    }
+  },
+  "main": "./dist/index.cjs",
+  "module": "./dist/index.js",
+  "types": "./dist/index.d.ts",
+  "files": ["dist"],
+  "scripts": {
+    "build": "tsup",
+    "prepublishOnly": "pnpm build"
+  },
+  "author": "Isaac Chang <chang.isaac97@gmail.com>",
+  "license": "MIT",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/lightlayer-dev/agent-layer-ts.git",
+    "directory": "packages/koa"
+  },
+  "homepage": "https://company.lightlayer.dev",
+  "bugs": {
+    "url": "https://github.com/lightlayer-dev/agent-layer-ts/issues"
+  },
+  "keywords": [
+    "ai",
+    "agent",
+    "llm",
+    "koa",
+    "middleware",
+    "agent-native",
+    "rate-limit",
+    "llms-txt",
+    "openapi"
+  ],
+  "dependencies": {
+    "@agent-layer/core": "workspace:*"
+  },
+  "devDependencies": {
+    "@types/koa": "^2.15.0",
+    "@types/koa__router": "^12.0.4",
+    "@types/supertest": "^7.2.0",
+    "koa": "^2.15.0",
+    "@koa/router": "^13.1.0",
+    "supertest": "^7.2.2",
+    "tsup": "^8.0.0",
+    "typescript": "^5.4.0"
+  },
+  "peerDependencies": {
+    "koa": "^2.15.0",
+    "@koa/router": "^12.0.0 || ^13.0.0"
+  }
+}

--- a/packages/koa/src/agent-auth.test.ts
+++ b/packages/koa/src/agent-auth.test.ts
@@ -1,0 +1,85 @@
+import { describe, it, expect, vi } from "vitest";
+import { agentAuth } from "./agent-auth.js";
+
+function mockCtx(overrides: Record<string, unknown> = {}): any {
+  const _headers: Record<string, string> = {};
+  return {
+    headers: {},
+    status: 200,
+    body: null as unknown,
+    _headers,
+    set(key: string, val: string) {
+      _headers[key.toLowerCase()] = val;
+    },
+    ...overrides,
+  };
+}
+
+describe("agentAuth", () => {
+  const config = {
+    issuer: "https://auth.example.com",
+    authorizationUrl: "https://auth.example.com/authorize",
+    tokenUrl: "https://auth.example.com/token",
+    scopes: { read: "Read access", write: "Write access" },
+  };
+
+  it("oauthDiscovery returns the discovery document", () => {
+    const handlers = agentAuth(config);
+    const ctx = mockCtx();
+
+    handlers.oauthDiscovery(ctx);
+
+    expect(ctx.body).toEqual({
+      issuer: "https://auth.example.com",
+      authorization_endpoint: "https://auth.example.com/authorize",
+      token_endpoint: "https://auth.example.com/token",
+      scopes_supported: ["read", "write"],
+    });
+  });
+
+  it("requireAuth returns 401 when no Authorization header", async () => {
+    const handlers = agentAuth(config);
+    const middleware = handlers.requireAuth();
+    const ctx = mockCtx();
+    const next = vi.fn();
+
+    await middleware(ctx, next);
+
+    expect(ctx.status).toBe(401);
+    expect(ctx.body.error.code).toBe("authentication_required");
+    expect(next).not.toHaveBeenCalled();
+  });
+
+  it("requireAuth sets WWW-Authenticate header", async () => {
+    const handlers = agentAuth(config);
+    const middleware = handlers.requireAuth();
+    const ctx = mockCtx();
+
+    await middleware(ctx, vi.fn());
+
+    expect(ctx._headers["www-authenticate"]).toContain("Bearer");
+    expect(ctx._headers["www-authenticate"]).toContain("realm=");
+  });
+
+  it("requireAuth calls next when Authorization header is present", async () => {
+    const handlers = agentAuth(config);
+    const middleware = handlers.requireAuth();
+    const ctx = mockCtx({ headers: { authorization: "Bearer token123" } });
+    const next = vi.fn();
+
+    await middleware(ctx, next);
+
+    expect(next).toHaveBeenCalled();
+    expect(ctx.status).toBe(200);
+  });
+
+  it("uses custom realm", async () => {
+    const handlers = agentAuth({ ...config, realm: "my-api" });
+    const middleware = handlers.requireAuth();
+    const ctx = mockCtx();
+
+    await middleware(ctx, vi.fn());
+
+    expect(ctx._headers["www-authenticate"]).toContain('realm="my-api"');
+  });
+});

--- a/packages/koa/src/agent-auth.ts
+++ b/packages/koa/src/agent-auth.ts
@@ -1,0 +1,68 @@
+import type { Context, Next } from "koa";
+import type { AgentAuthConfig } from "@agent-layer/core";
+import { formatError } from "@agent-layer/core";
+
+/**
+ * Generate the OAuth discovery document.
+ */
+function oauthDiscoveryDocument(config: AgentAuthConfig): Record<string, unknown> {
+  const doc: Record<string, unknown> = {};
+
+  if (config.issuer) doc["issuer"] = config.issuer;
+  if (config.authorizationUrl) doc["authorization_endpoint"] = config.authorizationUrl;
+  if (config.tokenUrl) doc["token_endpoint"] = config.tokenUrl;
+  if (config.scopes) doc["scopes_supported"] = Object.keys(config.scopes);
+
+  return doc;
+}
+
+/**
+ * Create route handlers and middleware for agent authentication.
+ */
+export function agentAuth(config: AgentAuthConfig) {
+  const realm = config.realm ?? "api";
+  const discovery = oauthDiscoveryDocument(config);
+
+  return {
+    /**
+     * GET /.well-known/oauth-authorization-server handler.
+     */
+    oauthDiscovery(ctx: Context): void {
+      ctx.body = discovery;
+    },
+
+    /**
+     * Middleware that returns structured 401 responses with WWW-Authenticate header.
+     * Use this to protect routes that require authentication.
+     */
+    requireAuth() {
+      return async function requireAuthMiddleware(
+        ctx: Context,
+        next: Next,
+      ): Promise<void> {
+        const authHeader = ctx.headers.authorization;
+
+        if (!authHeader) {
+          const wwwAuth = [`Bearer realm="${realm}"`];
+          if (config.scopes) {
+            wwwAuth.push(`scope="${Object.keys(config.scopes).join(" ")}"`);
+          }
+          ctx.set("WWW-Authenticate", wwwAuth.join(", "));
+
+          const envelope = formatError({
+            code: "authentication_required",
+            message: "This endpoint requires authentication.",
+            status: 401,
+            docs_url: config.authorizationUrl,
+          });
+
+          ctx.status = 401;
+          ctx.body = { error: envelope };
+          return;
+        }
+
+        await next();
+      };
+    },
+  };
+}

--- a/packages/koa/src/agent-errors.test.ts
+++ b/packages/koa/src/agent-errors.test.ts
@@ -1,0 +1,137 @@
+import { describe, it, expect, vi } from "vitest";
+import { agentErrors, notFoundHandler } from "./agent-errors.js";
+import { AgentError } from "@agent-layer/core";
+
+function mockCtx(overrides: Record<string, unknown> = {}): any {
+  const _headers: Record<string, string> = {};
+  return {
+    headers: { accept: "application/json", "user-agent": "test-agent" },
+    method: "GET",
+    path: "/test",
+    status: 404,
+    body: null as unknown,
+    type: "",
+    _headers,
+    set(key: string, val: string) {
+      _headers[key.toLowerCase()] = val;
+    },
+    ...overrides,
+  };
+}
+
+describe("agentErrors middleware", () => {
+  it("formats AgentError as JSON for agent clients", async () => {
+    const middleware = agentErrors();
+    const ctx = mockCtx();
+    const err = new AgentError({ code: "bad_input", message: "Bad", status: 400 });
+
+    await middleware(ctx, async () => { throw err; });
+
+    expect(ctx.status).toBe(400);
+    expect(ctx.body.error.code).toBe("bad_input");
+    expect(ctx.body.error.type).toBe("invalid_request_error");
+  });
+
+  it("formats generic Error with status property", async () => {
+    const middleware = agentErrors();
+    const ctx = mockCtx();
+    const err = Object.assign(new Error("Not found"), { status: 404 });
+
+    await middleware(ctx, async () => { throw err; });
+
+    expect(ctx.status).toBe(404);
+    expect(ctx.body.error.code).toBe("internal_error");
+  });
+
+  it("defaults to 500 for plain errors", async () => {
+    const middleware = agentErrors();
+    const ctx = mockCtx();
+
+    await middleware(ctx, async () => { throw new Error("oops"); });
+
+    expect(ctx.status).toBe(500);
+    expect(ctx.body.error.is_retriable).toBe(true);
+  });
+
+  it("returns HTML for browser Accept header", async () => {
+    const middleware = agentErrors();
+    const ctx = mockCtx({
+      headers: { accept: "text/html", "user-agent": "Mozilla/5.0" },
+    });
+
+    await middleware(ctx, async () => { throw new Error("fail"); });
+
+    expect(ctx.type).toBe("html");
+    expect(typeof ctx.body).toBe("string");
+    expect(ctx.body).toContain("<!DOCTYPE html>");
+    expect(ctx.body).toContain("500");
+  });
+
+  it("sets Retry-After header for rate limit errors", async () => {
+    const middleware = agentErrors();
+    const ctx = mockCtx();
+    const err = new AgentError({
+      code: "rate_limit",
+      message: "Slow down",
+      status: 429,
+      retry_after: 30,
+    });
+
+    await middleware(ctx, async () => { throw err; });
+
+    expect(ctx._headers["retry-after"]).toBe("30");
+  });
+
+  it("returns JSON for curl-like user agents", async () => {
+    const middleware = agentErrors();
+    const ctx = mockCtx({
+      headers: { accept: "*/*", "user-agent": "curl/7.68.0" },
+    });
+
+    await middleware(ctx, async () => { throw new Error("fail"); });
+
+    expect(ctx.body).toHaveProperty("error");
+    expect(ctx.body.error.code).toBe("internal_error");
+  });
+});
+
+describe("notFoundHandler", () => {
+  it("returns 404 JSON for agents", async () => {
+    const middleware = notFoundHandler();
+    const ctx = mockCtx({ method: "GET", path: "/nope" });
+
+    await middleware(ctx, async () => {});
+
+    expect(ctx.status).toBe(404);
+    expect(ctx.body.error.code).toBe("not_found");
+    expect(ctx.body.error.message).toContain("GET /nope");
+  });
+
+  it("returns 404 HTML for browsers", async () => {
+    const middleware = notFoundHandler();
+    const ctx = mockCtx({
+      method: "POST",
+      path: "/missing",
+      headers: { accept: "text/html", "user-agent": "Mozilla/5.0" },
+    });
+
+    await middleware(ctx, async () => {});
+
+    expect(ctx.status).toBe(404);
+    expect(typeof ctx.body).toBe("string");
+    expect(ctx.body).toContain("not_found");
+  });
+
+  it("does not override existing response body", async () => {
+    const middleware = notFoundHandler();
+    const ctx = mockCtx();
+    ctx.status = 200;
+
+    await middleware(ctx, async () => {
+      ctx.body = { ok: true };
+      ctx.status = 200;
+    });
+
+    expect(ctx.body).toEqual({ ok: true });
+  });
+});

--- a/packages/koa/src/agent-errors.ts
+++ b/packages/koa/src/agent-errors.ts
@@ -1,0 +1,101 @@
+import type { Context, Next } from "koa";
+import { AgentError, formatError, notFoundError } from "@agent-layer/core";
+import type { AgentErrorEnvelope } from "@agent-layer/core";
+
+/**
+ * Determine whether the client prefers JSON (i.e., is an agent) based on Accept header.
+ */
+function prefersJson(ctx: Context): boolean {
+  const accept = ctx.headers.accept ?? "";
+  if (accept.includes("application/json")) return true;
+  if (accept.includes("text/html")) return false;
+  // User-agent heuristic: non-browser clients likely want JSON
+  const ua = ctx.headers["user-agent"] ?? "";
+  if (!ua || /bot|crawl|spider|agent|curl|httpie|python|node|go-http/i.test(ua)) {
+    return true;
+  }
+  return false;
+}
+
+function renderHtmlError(envelope: AgentErrorEnvelope): string {
+  return `<!DOCTYPE html>
+<html lang="en">
+<head><meta charset="utf-8"><title>Error ${envelope.status}</title></head>
+<body>
+  <h1>${envelope.status} — ${envelope.code}</h1>
+  <p>${envelope.message}</p>
+</body>
+</html>`;
+}
+
+/**
+ * Koa error-handling middleware.
+ * Content-negotiates between JSON (for agents) and HTML (for browsers).
+ * Mount this as the outermost middleware (first `app.use()`) so it catches all downstream errors.
+ */
+export function agentErrors() {
+  return async function agentErrorHandler(
+    ctx: Context,
+    next: Next,
+  ): Promise<void> {
+    try {
+      await next();
+    } catch (err: unknown) {
+      const error = err as Error;
+      let envelope: AgentErrorEnvelope;
+
+      if (error instanceof AgentError) {
+        envelope = error.envelope;
+      } else {
+        const status =
+          (error as unknown as { status?: number }).status ??
+          (error as unknown as { statusCode?: number }).statusCode ??
+          500;
+        envelope = formatError({
+          code: "internal_error",
+          message: error.message || "An unexpected error occurred.",
+          status,
+        });
+      }
+
+      ctx.status = envelope.status;
+
+      if (envelope.retry_after != null) {
+        ctx.set("Retry-After", String(envelope.retry_after));
+      }
+
+      if (prefersJson(ctx)) {
+        ctx.body = { error: envelope };
+      } else {
+        ctx.type = "html";
+        ctx.body = renderHtmlError(envelope);
+      }
+    }
+  };
+}
+
+/**
+ * 404 catch-all middleware. Mount after all routes.
+ * In Koa, this checks if no downstream middleware set a response body.
+ */
+export function notFoundHandler() {
+  return async function handleNotFound(
+    ctx: Context,
+    next: Next,
+  ): Promise<void> {
+    await next();
+
+    // Only trigger 404 if no body was set and status is still 404
+    if (ctx.body == null && ctx.status === 404) {
+      const envelope = notFoundError(`No route matches ${ctx.method} ${ctx.path}`);
+      ctx.status = 404;
+
+      if (prefersJson(ctx)) {
+        ctx.body = { error: envelope };
+      } else {
+        ctx.type = "html";
+        ctx.body = renderHtmlError(envelope);
+      }
+    }
+  };
+}

--- a/packages/koa/src/agent-meta.test.ts
+++ b/packages/koa/src/agent-meta.test.ts
@@ -1,0 +1,89 @@
+import { describe, it, expect, vi } from "vitest";
+import { agentMeta } from "./agent-meta.js";
+
+function mockCtx(overrides: Record<string, unknown> = {}): any {
+  return {
+    type: "",
+    body: null as unknown,
+    ...overrides,
+  };
+}
+
+describe("agentMeta middleware", () => {
+  it("injects data-agent-id into <body> tag", async () => {
+    const middleware = agentMeta();
+    const ctx = mockCtx();
+
+    await middleware(ctx, async () => {
+      ctx.type = "text/html";
+      ctx.body = "<html><body><p>Hello</p></body></html>";
+    });
+
+    expect(ctx.body).toContain('data-agent-id="root"');
+  });
+
+  it("injects meta tags into <head>", async () => {
+    const middleware = agentMeta({
+      metaTags: { "ai-purpose": "api-docs" },
+    });
+    const ctx = mockCtx();
+
+    await middleware(ctx, async () => {
+      ctx.type = "text/html";
+      ctx.body = '<html><head><title>Test</title></head><body></body></html>';
+    });
+
+    expect(ctx.body).toContain('name="ai-purpose"');
+    expect(ctx.body).toContain('content="api-docs"');
+  });
+
+  it("adds ARIA role=main to <main> tags", async () => {
+    const middleware = agentMeta();
+    const ctx = mockCtx();
+
+    await middleware(ctx, async () => {
+      ctx.type = "text/html";
+      ctx.body = "<html><body><main><p>Content</p></main></body></html>";
+    });
+
+    expect(ctx.body).toContain('role="main"');
+  });
+
+  it("does not modify non-HTML responses", async () => {
+    const middleware = agentMeta();
+    const ctx = mockCtx();
+    const jsonData = '{"key": "value"}';
+
+    await middleware(ctx, async () => {
+      ctx.type = "application/json";
+      ctx.body = jsonData;
+    });
+
+    expect(ctx.body).toBe(jsonData);
+  });
+
+  it("uses custom agent ID attribute name", async () => {
+    const middleware = agentMeta({ agentIdAttribute: "data-bot-id" });
+    const ctx = mockCtx();
+
+    await middleware(ctx, async () => {
+      ctx.type = "text/html";
+      ctx.body = "<html><body><p>Hi</p></body></html>";
+    });
+
+    expect(ctx.body).toContain('data-bot-id="root"');
+    expect(ctx.body).not.toContain("data-agent-id");
+  });
+
+  it("skips ARIA when ariaLandmarks is false", async () => {
+    const middleware = agentMeta({ ariaLandmarks: false });
+    const ctx = mockCtx();
+
+    await middleware(ctx, async () => {
+      ctx.type = "text/html";
+      ctx.body = "<html><body><main><p>Content</p></main></body></html>";
+    });
+
+    expect(ctx.body).not.toContain('role="main"');
+  });
+});

--- a/packages/koa/src/agent-meta.ts
+++ b/packages/koa/src/agent-meta.ts
@@ -1,0 +1,52 @@
+import type { Context, Next } from "koa";
+import type { AgentMetaConfig } from "@agent-layer/core";
+
+/**
+ * Koa response-transform middleware for HTML responses.
+ * Injects data-agent-id attributes, ARIA landmarks, and meta tags.
+ */
+export function agentMeta(config: AgentMetaConfig = {}) {
+  const attrName = config.agentIdAttribute ?? "data-agent-id";
+  const injectAria = config.ariaLandmarks !== false;
+  const metaTags = config.metaTags ?? {};
+
+  return async function agentMetaMiddleware(
+    ctx: Context,
+    next: Next,
+  ): Promise<void> {
+    await next();
+
+    // Only transform HTML string responses
+    const contentType = ctx.type || "";
+    if (
+      typeof ctx.body === "string" &&
+      contentType.includes("text/html")
+    ) {
+      let html = ctx.body;
+
+      // Inject meta tags into <head>
+      const metaTagsHtml = Object.entries(metaTags)
+        .map(([name, content]) => `<meta name="${name}" content="${content}">`)
+        .join("\n    ");
+
+      if (metaTagsHtml && html.includes("</head>")) {
+        html = html.replace("</head>", `    ${metaTagsHtml}\n</head>`);
+      }
+
+      // Add data-agent-id to <body>
+      if (html.includes("<body")) {
+        html = html.replace("<body", `<body ${attrName}="root"`);
+      }
+
+      // Add ARIA landmarks
+      if (injectAria && html.includes("<main")) {
+        html = html.replace(
+          /<main(?![^>]*role=)/,
+          '<main role="main"',
+        );
+      }
+
+      ctx.body = html;
+    }
+  };
+}

--- a/packages/koa/src/discovery.test.ts
+++ b/packages/koa/src/discovery.test.ts
@@ -1,0 +1,74 @@
+import { describe, it, expect } from "vitest";
+import { discoveryRoutes } from "./discovery.js";
+
+function mockCtx(): any {
+  return {
+    statusCode: 200,
+    status: 200,
+    body: null as unknown,
+  };
+}
+
+describe("discoveryRoutes", () => {
+  it("wellKnownAi returns the manifest", () => {
+    const handlers = discoveryRoutes({
+      manifest: { name: "My API", description: "Test" },
+    });
+    const ctx = mockCtx();
+
+    handlers.wellKnownAi(ctx);
+
+    expect(ctx.body).toEqual({ name: "My API", description: "Test" });
+  });
+
+  it("openApiJson returns the spec when configured", () => {
+    const spec = { openapi: "3.0.0", info: { title: "API", version: "1.0" } };
+    const handlers = discoveryRoutes({
+      manifest: { name: "API" },
+      openApiSpec: spec,
+    });
+    const ctx = mockCtx();
+
+    handlers.openApiJson(ctx);
+
+    expect(ctx.body).toEqual(spec);
+  });
+
+  it("openApiJson returns 404 when no spec configured", () => {
+    const handlers = discoveryRoutes({ manifest: { name: "API" } });
+    const ctx = mockCtx();
+
+    handlers.openApiJson(ctx);
+
+    expect(ctx.status).toBe(404);
+    expect(ctx.body.error.code).toBe("no_openapi_spec");
+  });
+
+  it("jsonLd returns valid JSON-LD", () => {
+    const handlers = discoveryRoutes({
+      manifest: { name: "API", description: "A test" },
+    });
+    const ctx = mockCtx();
+
+    handlers.jsonLd(ctx);
+
+    expect(ctx.body["@context"]).toBe("https://schema.org");
+    expect(ctx.body["@type"]).toBe("WebAPI");
+    expect(ctx.body["name"]).toBe("API");
+  });
+
+  it("manifest includes auth configuration", () => {
+    const handlers = discoveryRoutes({
+      manifest: {
+        name: "API",
+        auth: { type: "oauth2", token_url: "https://auth.example.com/token" },
+      },
+    });
+    const ctx = mockCtx();
+
+    handlers.wellKnownAi(ctx);
+
+    expect(ctx.body.auth.type).toBe("oauth2");
+    expect(ctx.body.auth.token_url).toBe("https://auth.example.com/token");
+  });
+});

--- a/packages/koa/src/discovery.ts
+++ b/packages/koa/src/discovery.ts
@@ -1,0 +1,47 @@
+import type { Context } from "koa";
+import { generateAIManifest, generateJsonLd } from "@agent-layer/core";
+import type { DiscoveryConfig } from "@agent-layer/core";
+
+/**
+ * Create Koa route handlers for /.well-known/ai and /openapi.json.
+ */
+export function discoveryRoutes(config: DiscoveryConfig) {
+  const manifest = generateAIManifest(config);
+  const jsonLd = generateJsonLd(config);
+
+  return {
+    /**
+     * GET /.well-known/ai handler.
+     */
+    wellKnownAi(ctx: Context): void {
+      ctx.body = manifest;
+    },
+
+    /**
+     * GET /openapi.json handler.
+     */
+    openApiJson(ctx: Context): void {
+      if (config.openApiSpec) {
+        ctx.body = config.openApiSpec;
+      } else {
+        ctx.status = 404;
+        ctx.body = {
+          error: {
+            type: "not_found_error",
+            code: "no_openapi_spec",
+            message: "No OpenAPI spec has been configured.",
+            status: 404,
+            is_retriable: false,
+          },
+        };
+      }
+    },
+
+    /**
+     * Returns JSON-LD structured data for embedding in HTML.
+     */
+    jsonLd(ctx: Context): void {
+      ctx.body = jsonLd;
+    },
+  };
+}

--- a/packages/koa/src/index.test.ts
+++ b/packages/koa/src/index.test.ts
@@ -1,0 +1,93 @@
+import { describe, it, expect, vi } from "vitest";
+
+// Mock @koa/router since we're testing composition, not Koa itself
+vi.mock("@koa/router", () => {
+  class MockRouter {
+    _handlers: Record<string, Array<{ path?: string; handler: Function }>> = {
+      get: [],
+      use: [],
+    };
+
+    get(path: string | Function, handler?: Function) {
+      if (typeof path === "function") {
+        this._handlers.use.push({ handler: path });
+      } else {
+        this._handlers.get.push({ path, handler: handler! });
+      }
+      return this;
+    }
+
+    use(pathOrHandler: string | Function, handler?: Function) {
+      if (typeof pathOrHandler === "function") {
+        this._handlers.use.push({ handler: pathOrHandler });
+      } else {
+        this._handlers.use.push({ path: pathOrHandler, handler: handler! });
+      }
+      return this;
+    }
+  }
+
+  return { default: MockRouter };
+});
+
+import { agentLayer } from "./index.js";
+
+describe("agentLayer one-liner", () => {
+  it("returns a router-like object", () => {
+    const router = agentLayer({});
+    expect(router).toBeDefined();
+    expect(typeof router.use).toBe("function");
+    expect(typeof router.get).toBe("function");
+  });
+
+  it("registers llms.txt routes when configured", () => {
+    const router = agentLayer({
+      llmsTxt: { title: "Test API" },
+    }) as any;
+
+    const paths = router._handlers.get.map((h: any) => h.path);
+    expect(paths).toContain("/llms.txt");
+    expect(paths).toContain("/llms-full.txt");
+  });
+
+  it("registers discovery routes when configured", () => {
+    const router = agentLayer({
+      discovery: { manifest: { name: "API" } },
+    }) as any;
+
+    const paths = router._handlers.get.map((h: any) => h.path);
+    expect(paths).toContain("/.well-known/ai");
+    expect(paths).toContain("/openapi.json");
+  });
+
+  it("registers auth discovery route when configured", () => {
+    const router = agentLayer({
+      agentAuth: {
+        issuer: "https://auth.example.com",
+        tokenUrl: "https://auth.example.com/token",
+      },
+    }) as any;
+
+    const paths = router._handlers.get.map((h: any) => h.path);
+    expect(paths).toContain("/.well-known/oauth-authorization-server");
+  });
+
+  it("registers error handlers when errors is not false", () => {
+    const router = agentLayer({ errors: true }) as any;
+    expect(router._handlers.use.length).toBeGreaterThan(0);
+  });
+
+  it("skips features that are disabled", () => {
+    const router = agentLayer({
+      errors: false,
+      rateLimit: false,
+      llmsTxt: false,
+      discovery: false,
+      agentAuth: false,
+      agentMeta: false,
+    }) as any;
+
+    expect(router._handlers.get.length).toBe(0);
+    expect(router._handlers.use.length).toBe(0);
+  });
+});

--- a/packages/koa/src/index.ts
+++ b/packages/koa/src/index.ts
@@ -1,0 +1,61 @@
+import Router from "@koa/router";
+import type { AgentLayerConfig } from "@agent-layer/core";
+import { agentErrors, notFoundHandler } from "./agent-errors.js";
+import { rateLimits } from "./rate-limits.js";
+import { llmsTxtRoutes } from "./llms-txt.js";
+import { discoveryRoutes } from "./discovery.js";
+import { agentMeta } from "./agent-meta.js";
+import { agentAuth } from "./agent-auth.js";
+
+export { agentErrors, notFoundHandler } from "./agent-errors.js";
+export { rateLimits } from "./rate-limits.js";
+export { llmsTxtRoutes } from "./llms-txt.js";
+export { discoveryRoutes } from "./discovery.js";
+export { agentMeta } from "./agent-meta.js";
+export { agentAuth } from "./agent-auth.js";
+
+/**
+ * One-liner that composes all agent-layer middleware onto a single Koa Router.
+ * Each feature can be disabled by setting it to `false` in the config.
+ */
+export function agentLayer(config: AgentLayerConfig): Router {
+  const router = new Router();
+
+  // Rate limiting (early — before routes)
+  if (config.rateLimit !== false && config.rateLimit) {
+    router.use(rateLimits(config.rateLimit));
+  }
+
+  // Agent meta (HTML transforms)
+  if (config.agentMeta !== false && config.agentMeta) {
+    router.use(agentMeta(config.agentMeta));
+  }
+
+  // LLMs.txt routes
+  if (config.llmsTxt !== false && config.llmsTxt) {
+    const handlers = llmsTxtRoutes(config.llmsTxt);
+    router.get("/llms.txt", handlers.llmsTxt);
+    router.get("/llms-full.txt", handlers.llmsFullTxt);
+  }
+
+  // Discovery routes
+  if (config.discovery !== false && config.discovery) {
+    const handlers = discoveryRoutes(config.discovery);
+    router.get("/.well-known/ai", handlers.wellKnownAi);
+    router.get("/openapi.json", handlers.openApiJson);
+  }
+
+  // Auth discovery
+  if (config.agentAuth !== false && config.agentAuth) {
+    const handlers = agentAuth(config.agentAuth);
+    router.get("/.well-known/oauth-authorization-server", handlers.oauthDiscovery);
+  }
+
+  // Error handling (late — after routes)
+  if (config.errors !== false) {
+    router.use(notFoundHandler());
+    router.use(agentErrors());
+  }
+
+  return router;
+}

--- a/packages/koa/src/llms-txt.test.ts
+++ b/packages/koa/src/llms-txt.test.ts
@@ -1,0 +1,76 @@
+import { describe, it, expect } from "vitest";
+import { llmsTxtRoutes } from "./llms-txt.js";
+
+function mockCtx(): any {
+  return {
+    type: "",
+    body: null as unknown,
+  };
+}
+
+describe("llmsTxtRoutes", () => {
+  it("llmsTxt handler returns text/plain content", () => {
+    const handlers = llmsTxtRoutes({ title: "My API" });
+    const ctx = mockCtx();
+
+    handlers.llmsTxt(ctx);
+
+    expect(ctx.type).toBe("text/plain");
+    expect(ctx.body).toContain("# My API");
+  });
+
+  it("llmsFullTxt handler returns text/plain content", () => {
+    const handlers = llmsTxtRoutes({ title: "My API" }, [
+      { method: "GET", path: "/users", summary: "List users" },
+    ]);
+    const ctx = mockCtx();
+
+    handlers.llmsFullTxt(ctx);
+
+    expect(ctx.type).toBe("text/plain");
+    expect(ctx.body).toContain("# My API");
+    expect(ctx.body).toContain("GET /users");
+  });
+
+  it("includes description in llmsTxt output", () => {
+    const handlers = llmsTxtRoutes({
+      title: "API",
+      description: "A test API",
+    });
+    const ctx = mockCtx();
+
+    handlers.llmsTxt(ctx);
+
+    expect(ctx.body).toContain("> A test API");
+  });
+
+  it("includes sections in llmsTxt output", () => {
+    const handlers = llmsTxtRoutes({
+      title: "API",
+      sections: [{ title: "Auth", content: "Use tokens." }],
+    });
+    const ctx = mockCtx();
+
+    handlers.llmsTxt(ctx);
+
+    expect(ctx.body).toContain("## Auth");
+    expect(ctx.body).toContain("Use tokens.");
+  });
+
+  it("llmsFullTxt includes parameters for routes", () => {
+    const handlers = llmsTxtRoutes({ title: "API" }, [
+      {
+        method: "POST",
+        path: "/items",
+        parameters: [
+          { name: "name", in: "body", required: true, description: "Item name" },
+        ],
+      },
+    ]);
+    const ctx = mockCtx();
+
+    handlers.llmsFullTxt(ctx);
+
+    expect(ctx.body).toContain("`name` (body) (required)");
+  });
+});

--- a/packages/koa/src/llms-txt.ts
+++ b/packages/koa/src/llms-txt.ts
@@ -1,0 +1,29 @@
+import type { Context } from "koa";
+import { generateLlmsTxt, generateLlmsFullTxt } from "@agent-layer/core";
+import type { LlmsTxtConfig, RouteMetadata } from "@agent-layer/core";
+
+/**
+ * Create Koa route handlers for GET /llms.txt and /llms-full.txt.
+ */
+export function llmsTxtRoutes(config: LlmsTxtConfig, routes: RouteMetadata[] = []) {
+  const txt = generateLlmsTxt(config);
+  const fullTxt = generateLlmsFullTxt(config, routes);
+
+  return {
+    /**
+     * GET /llms.txt handler — returns the concise version.
+     */
+    llmsTxt(ctx: Context): void {
+      ctx.type = "text/plain";
+      ctx.body = txt;
+    },
+
+    /**
+     * GET /llms-full.txt handler — returns the full version with route docs.
+     */
+    llmsFullTxt(ctx: Context): void {
+      ctx.type = "text/plain";
+      ctx.body = fullTxt;
+    },
+  };
+}

--- a/packages/koa/src/rate-limits.test.ts
+++ b/packages/koa/src/rate-limits.test.ts
@@ -1,0 +1,90 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import { rateLimits } from "./rate-limits.js";
+
+function mockCtx(overrides: Record<string, unknown> = {}): any {
+  const headers: Record<string, string> = {};
+  return {
+    request: { headers: {}, ...overrides },
+    headers: {},
+    status: 200,
+    body: null as unknown,
+    _headers: headers,
+    set(key: string, val: string) {
+      headers[key.toLowerCase()] = val;
+    },
+    get response() {
+      return { headers };
+    },
+  };
+}
+
+describe("rateLimits middleware", () => {
+  beforeEach(() => vi.useFakeTimers());
+  afterEach(() => vi.useRealTimers());
+
+  it("sets X-RateLimit-* headers on allowed requests", async () => {
+    const middleware = rateLimits({ max: 10 });
+    const ctx = mockCtx();
+    const next = vi.fn();
+
+    await middleware(ctx, next);
+
+    expect(ctx._headers["x-ratelimit-limit"]).toBe("10");
+    expect(ctx._headers["x-ratelimit-remaining"]).toBe("9");
+    expect(ctx._headers["x-ratelimit-reset"]).toBeDefined();
+    expect(next).toHaveBeenCalled();
+  });
+
+  it("returns 429 when limit exceeded", async () => {
+    const middleware = rateLimits({ max: 1 });
+    const ctx = mockCtx();
+    const next = vi.fn();
+
+    await middleware(ctx, next);
+
+    const ctx2 = mockCtx();
+    await middleware(ctx2, vi.fn());
+
+    expect(ctx2.status).toBe(429);
+    expect(ctx2.body.error.code).toBe("rate_limit_exceeded");
+    expect(ctx2._headers["retry-after"]).toBeDefined();
+  });
+
+  it("sets remaining to 0 on blocked requests", async () => {
+    const middleware = rateLimits({ max: 1 });
+    const ctx = mockCtx();
+
+    await middleware(ctx, vi.fn());
+
+    const ctx2 = mockCtx();
+    await middleware(ctx2, vi.fn());
+
+    expect(ctx2._headers["x-ratelimit-remaining"]).toBe("0");
+  });
+
+  it("allows requests again after window expires", async () => {
+    const middleware = rateLimits({ max: 1, windowMs: 1000 });
+    const ctx = mockCtx();
+
+    await middleware(ctx, vi.fn());
+    vi.advanceTimersByTime(1001);
+
+    const ctx2 = mockCtx();
+    const next = vi.fn();
+    await middleware(ctx2, next);
+
+    expect(next).toHaveBeenCalled();
+    expect(ctx2._headers["x-ratelimit-remaining"]).toBe("0");
+  });
+
+  it("propagates store errors", async () => {
+    const errorStore = {
+      increment: async () => { throw new Error("store error"); },
+      get: async () => 0,
+      reset: async () => {},
+    };
+    const middleware = rateLimits({ max: 10, store: errorStore });
+
+    await expect(middleware(mockCtx(), vi.fn())).rejects.toThrow("store error");
+  });
+});

--- a/packages/koa/src/rate-limits.ts
+++ b/packages/koa/src/rate-limits.ts
@@ -1,0 +1,36 @@
+import type { Context, Next } from "koa";
+import { createRateLimiter, rateLimitError } from "@agent-layer/core";
+import type { RateLimitConfig } from "@agent-layer/core";
+
+/**
+ * Koa middleware that adds X-RateLimit-* headers to every response
+ * and returns 429 with Retry-After when the limit is exceeded.
+ */
+export function rateLimits(config: RateLimitConfig) {
+  const check = createRateLimiter(config);
+
+  return async function rateLimitMiddleware(
+    ctx: Context,
+    next: Next,
+  ): Promise<void> {
+    const result = await check(ctx.request);
+
+    ctx.set("X-RateLimit-Limit", String(result.limit));
+    ctx.set("X-RateLimit-Remaining", String(result.remaining));
+    ctx.set(
+      "X-RateLimit-Reset",
+      String(Math.ceil((Date.now() + result.resetMs) / 1000)),
+    );
+
+    if (!result.allowed) {
+      const retryAfter = result.retryAfter ?? Math.ceil(result.resetMs / 1000);
+      ctx.set("Retry-After", String(retryAfter));
+      const envelope = rateLimitError(retryAfter);
+      ctx.status = 429;
+      ctx.body = { error: envelope };
+      return;
+    }
+
+    await next();
+  };
+}

--- a/packages/koa/tsconfig.json
+++ b/packages/koa/tsconfig.json
@@ -1,0 +1,8 @@
+{
+  "extends": "../../tsconfig.json",
+  "compilerOptions": {
+    "rootDir": "src",
+    "outDir": "dist"
+  },
+  "include": ["src"]
+}

--- a/packages/koa/tsup.config.ts
+++ b/packages/koa/tsup.config.ts
@@ -1,0 +1,10 @@
+import { defineConfig } from "tsup";
+
+export default defineConfig({
+  entry: ["src/index.ts"],
+  format: ["esm", "cjs"],
+  dts: true,
+  clean: true,
+  sourcemap: true,
+  external: ["koa", "@koa/router"],
+});

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -52,6 +52,37 @@ importers:
         specifier: ^5.4.0
         version: 5.9.3
 
+  packages/koa:
+    dependencies:
+      '@agent-layer/core':
+        specifier: workspace:*
+        version: link:../core
+    devDependencies:
+      '@koa/router':
+        specifier: ^13.1.0
+        version: 13.1.1
+      '@types/koa':
+        specifier: ^2.15.0
+        version: 2.15.0
+      '@types/koa__router':
+        specifier: ^12.0.4
+        version: 12.0.5
+      '@types/supertest':
+        specifier: ^7.2.0
+        version: 7.2.0
+      koa:
+        specifier: ^2.15.0
+        version: 2.16.4
+      supertest:
+        specifier: ^7.2.2
+        version: 7.2.2
+      tsup:
+        specifier: ^8.0.0
+        version: 8.5.1(postcss@8.5.8)(typescript@5.9.3)
+      typescript:
+        specifier: ^5.4.0
+        version: 5.9.3
+
 packages:
 
   '@esbuild/aix-ppc64@0.21.5':
@@ -365,6 +396,11 @@ packages:
   '@jridgewell/trace-mapping@0.3.31':
     resolution: {integrity: sha512-zzNR+SdQSDJzc8joaeP8QQoCQr8NuYx2dIIytl1QeBEZHJ9uW6hebsrYgbz8hJwUQao3TWCMtmfV8Nu1twOLAw==}
 
+  '@koa/router@13.1.1':
+    resolution: {integrity: sha512-JQEuMANYRVHs7lm7KY9PCIjkgJk73h4m4J+g2mkw2Vo1ugPZ17UJVqEH8F+HeAdjKz5do1OaLe7ArDz+z308gw==}
+    engines: {node: '>= 18'}
+    deprecated: Please upgrade to v15 or higher. All reported bugs in this version are fixed in newer releases, dependencies have been updated, and security has been improved.
+
   '@noble/hashes@1.8.0':
     resolution: {integrity: sha512-jCs9ldd7NwzpgXDIf6P3+NrHh9/sD6CQdxHyjQI+h/6rDNo88ypBxxz45UDuZHz9r3tNz7N/VInSVoVdtXEI4A==}
     engines: {node: ^14.21.3 || >=16}
@@ -513,14 +549,23 @@ packages:
   '@sinclair/typebox@0.27.10':
     resolution: {integrity: sha512-MTBk/3jGLNB2tVxv6uLlFh1iu64iYOQ2PbdOSK3NW8JZsmlaOh2q6sdtKowBhfw8QFLmYNzTW4/oK4uATIi6ZA==}
 
+  '@types/accepts@1.3.7':
+    resolution: {integrity: sha512-Pay9fq2lM2wXPWbteBsRAGiWH2hig4ZE2asK+mm7kUzlxRTfL961rj89I6zV/E3PcIkDqyuBEcMxFT7rccugeQ==}
+
   '@types/body-parser@1.19.6':
     resolution: {integrity: sha512-HLFeCYgz89uk22N5Qg3dvGvsv46B8GLvKKo1zKG4NybA8U2DiEO3w9lqGg29t/tfLRJpJ6iQxnVw4OnB7MoM9g==}
 
   '@types/connect@3.4.38':
     resolution: {integrity: sha512-K6uROf1LD88uDQqJCktA4yzL1YYAK6NgfsI0v/mTgyPKWsX1CnJ0XPSDhViejru1GcRkLWb8RlzFYJRqGUbaug==}
 
+  '@types/content-disposition@0.5.9':
+    resolution: {integrity: sha512-8uYXI3Gw35MhiVYhG3s295oihrxRyytcRHjSjqnqZVDDy/xcGBRny7+Xj1Wgfhv5QzRtN2hB2dVRBUX9XW3UcQ==}
+
   '@types/cookiejar@2.1.5':
     resolution: {integrity: sha512-he+DHOWReW0nghN24E1WUqM0efK4kI9oTqDm6XmK8ZPe2djZ90BSNdGnIyCLzCPw7/pogPlGbzI2wHGGmi4O/Q==}
+
+  '@types/cookies@0.9.2':
+    resolution: {integrity: sha512-1AvkDdZM2dbyFybL4fxpuNCaWyv//0AwsuUk2DWeXyM1/5ZKm6W3z6mQi24RZ4l2ucY+bkSHzbDVpySqPGuV8A==}
 
   '@types/estree@1.0.8':
     resolution: {integrity: sha512-dWHzHa2WqEXI/O1E9OjrocMTKJl2mSrEolh1Iomrv6U+JuNwaHXsXx9bLu5gG7BUWFIN0skIQJQ/L1rIex4X6w==}
@@ -531,8 +576,23 @@ packages:
   '@types/express@4.17.25':
     resolution: {integrity: sha512-dVd04UKsfpINUnK0yBoYHDF3xu7xVH4BuDotC/xGuycx4CgbP48X/KF/586bcObxT0HENHXEU8Nqtu6NR+eKhw==}
 
+  '@types/http-assert@1.5.6':
+    resolution: {integrity: sha512-TTEwmtjgVbYAzZYWyeHPrrtWnfVkm8tQkP8P21uQifPgMRgjrow3XDEYqucuC8SKZJT7pUnhU/JymvjggxO9vw==}
+
   '@types/http-errors@2.0.5':
     resolution: {integrity: sha512-r8Tayk8HJnX0FztbZN7oVqGccWgw98T/0neJphO91KkmOzug1KkofZURD4UaD5uH8AqcFLfdPErnBod0u71/qg==}
+
+  '@types/keygrip@1.0.6':
+    resolution: {integrity: sha512-lZuNAY9xeJt7Bx4t4dx0rYCDqGPW8RXhQZK1td7d4H6E9zYbLoOtjBvfwdTKpsyxQI/2jv+armjX/RW+ZNpXOQ==}
+
+  '@types/koa-compose@3.2.9':
+    resolution: {integrity: sha512-BroAZ9FTvPiCy0Pi8tjD1OfJ7bgU1gQf0eR6e1Vm+JJATy9eKOG3hQMFtMciMawiSOVnLMdmUOC46s7HBhSTsA==}
+
+  '@types/koa@2.15.0':
+    resolution: {integrity: sha512-7QFsywoE5URbuVnG3loe03QXuGajrnotr3gQkXcEBShORai23MePfFYdhz90FEtBBpkyIYQbVD+evKtloCgX3g==}
+
+  '@types/koa__router@12.0.5':
+    resolution: {integrity: sha512-1HeLxuDn4n5it1yZYCSyOYXo++73zT0ffoviXnPxbwbxLbvDFEvWD9ZzpRiIpK4oKR0pi+K+Mk/ZjyROjW3HSw==}
 
   '@types/methods@1.1.4':
     resolution: {integrity: sha512-ymXWVrDiCxTBE3+RIrrP533E70eA+9qu7zdWoHuOmGujkYtzf4HQF96b8nwHLqhuf4ykX61IGRIB38CC6/sImQ==}
@@ -629,6 +689,10 @@ packages:
     resolution: {integrity: sha512-b6Ilus+c3RrdDk+JhLKUAQfzzgLEPy6wcXqS7f/xe1EETvsDP6GORG7SFuOs6cID5YkqchW/LXZbX5bc8j7ZcQ==}
     engines: {node: '>=8'}
 
+  cache-content-type@1.0.1:
+    resolution: {integrity: sha512-IKufZ1o4Ut42YUrZSo8+qnMTrFuKkvyoLXUywKz9GJ5BrhOFGhLdkx9sG4KAnVvbY6kEcSFjLQul+DVmBm2bgA==}
+    engines: {node: '>= 6.0.0'}
+
   call-bind-apply-helpers@1.0.2:
     resolution: {integrity: sha512-Sp1ablJ0ivDkSzjcaJdxEunN5/XvksFJ2sMBFfq6x0ryhQV/2b/KwFe21cMpmHtPOSij8K99/wSfoEuTObmuMQ==}
     engines: {node: '>= 0.4'}
@@ -647,6 +711,10 @@ packages:
   chokidar@4.0.3:
     resolution: {integrity: sha512-Qgzu8kfBvo+cA4962jnP1KkS6Dop5NS6g7R5LFYJr4b8Ub94PPQXUksCw9PvXoeXPRRddRNC5C1JQUR2SMGtnA==}
     engines: {node: '>= 14.16.0'}
+
+  co@4.6.0:
+    resolution: {integrity: sha512-QVb0dM5HvG+uaxitm8wONl7jltx8dqhfU33DcqtOZcLSVIKSDDLDi7+0LbAKiyI8hD9u42m2YxXSkMGWThaecQ==}
+    engines: {iojs: '>= 1.0.0', node: '>= 0.12.0'}
 
   combined-stream@1.0.8:
     resolution: {integrity: sha512-FQN4MRfuJeHf7cBbBMJFXhKSDq+2kAArBlmRBvcvFE5BB1HZKXtSFASDhdlz9zOYwxh8lDdnvmMOe/+5cdoEdg==}
@@ -688,6 +756,10 @@ packages:
   cookiejar@2.1.4:
     resolution: {integrity: sha512-LDx6oHrK+PhzLKJU9j5S7/Y3jM/mUHvD/DeI1WQmJn652iPC5Y4TBzC9l+5OMOXlyTTA+SmVUPm0HQUwpD5Jqw==}
 
+  cookies@0.9.1:
+    resolution: {integrity: sha512-TG2hpqe4ELx54QER/S3HQ9SRVnQnGBtKUz5bLQWtYAQ+o6GpgMs6sYUvaiJjVxb+UXwhRhAEP3m7LbsIZ77Hmw==}
+    engines: {node: '>= 0.8'}
+
   cross-spawn@7.0.6:
     resolution: {integrity: sha512-uV2QOWP2nWzsy2aMp8aRibhi9dlzF5Hgh5SHaB9OiTGEyDTiJJyx0uy51QXdyWbtAHNua4XJzUKca3OzKUd3vA==}
     engines: {node: '>= 8'}
@@ -713,9 +785,19 @@ packages:
     resolution: {integrity: sha512-SUwdGfqdKOwxCPeVYjwSyRpJ7Z+fhpwIAtmCUdZIWZ/YP5R9WAsyuSgpLVDi9bjWoN2LXHNss/dk3urXtdQxGg==}
     engines: {node: '>=6'}
 
+  deep-equal@1.0.1:
+    resolution: {integrity: sha512-bHtC0iYvWhyaTzvV3CZgPeZQqCOBGyGsVV7v4eevpdkLHfiSrXUdBG+qAuSz4RI70sszvjQ1QSZ98An1yNwpSw==}
+
   delayed-stream@1.0.0:
     resolution: {integrity: sha512-ZySD7Nf91aLB0RxL4KGrKHBXl7Eds1DAmEdcoVawXnLD7SDhpNgtuII2aAkg7a7QS41jxPSZ17p4VdGnMHk3MQ==}
     engines: {node: '>=0.4.0'}
+
+  delegates@1.0.0:
+    resolution: {integrity: sha512-bd2L678uiWATM6m5Z1VzNCErI3jiGzt6HGY8OVICs40JQq/HALfbyNJmp0UDakEY4pMMaN0Ly5om/B1VI/+xfQ==}
+
+  depd@1.1.2:
+    resolution: {integrity: sha512-7emPTl6Dpo6JRXOXjLRxck+FlLRX5847cLKEn00PLAgc3g2hTZZgr+e4c2v6QpSmLeFP3n5yUo7ft6avBK/5jQ==}
+    engines: {node: '>= 0.6'}
 
   depd@2.0.0:
     resolution: {integrity: sha512-g7nH6P6dyDioJogAAGprGpCtVImJhpPk/roCzdb3fIh61/s/nPsfR6onyMwkCAR/OlC3yBC0lESvUoQEAssIrw==}
@@ -738,6 +820,10 @@ packages:
 
   ee-first@1.1.1:
     resolution: {integrity: sha512-WMwm9LhRUo+WUaRN+vRuETqG89IgZphVSNkdFgeb6sS/E4OrDIN7t48CAewSHXc6C8lefD8KKfr5vY61brQlow==}
+
+  encodeurl@1.0.2:
+    resolution: {integrity: sha512-TPJXq8JqFaVYm2CWmPvnP2Iyo4ZSM7/QKcSmuMLDObfpH5fi7RUGmd/rTDf+rut/saiDiQEeVTNgAmJEdAOx0w==}
+    engines: {node: '>= 0.8'}
 
   encodeurl@2.0.0:
     resolution: {integrity: sha512-Q0n9HRi4m6JuGIV1eFlmvJB7ZEVxu93IrMyiMsGC0lrMJMWzRgx6WGquyfQgZVb31vhGgXnfmPNNXmxnOkRBrg==}
@@ -830,6 +916,10 @@ packages:
   function-bind@1.1.2:
     resolution: {integrity: sha512-7XHNxH7qX9xG5mIwxkhumTox/MIRNcOgDrxWsMt2pAr23WHp6MrRlN7FBSFpCpr+oVO0F744iUgR82nJMfG2SA==}
 
+  generator-function@2.0.1:
+    resolution: {integrity: sha512-SFdFmIJi+ybC0vjlHN0ZGVGHc3lgE0DxPAT0djjVg+kjOnSqclqmj0KQ7ykTOLP6YxoqOvuAODGdcHJn+43q3g==}
+    engines: {node: '>= 0.4'}
+
   get-func-name@2.0.2:
     resolution: {integrity: sha512-8vXOvuE167CtIc3OyItco7N/dpRtBbYOsPsXCz7X/PMnlGjYjSGuZJgM1Y7mmew7BKf9BqvLX2tnOVy1BBUsxQ==}
 
@@ -861,6 +951,14 @@ packages:
     resolution: {integrity: sha512-0hJU9SCPvmMzIBdZFqNPXWa6dqh7WdH0cII9y+CyS8rG3nL48Bclra9HmKhVVUHyPWNH5Y7xDwAB7bfgSjkUMQ==}
     engines: {node: '>= 0.4'}
 
+  http-assert@1.5.0:
+    resolution: {integrity: sha512-uPpH7OKX4H25hBmU6G1jWNaqJGpTXxey+YOUizJUAgu0AjLUeC8D73hTrhvDS5D+GJN1DN1+hhc/eF/wpxtp0w==}
+    engines: {node: '>= 0.8'}
+
+  http-errors@1.8.1:
+    resolution: {integrity: sha512-Kpk9Sm7NmI+RHhnj6OIWDI1d6fIoFAtFt9RLaTMRlg/8w49juAStsrBgp0Dp4OdxdVbRIeKhtCUvoi/RuAhO4g==}
+    engines: {node: '>= 0.6'}
+
   http-errors@2.0.1:
     resolution: {integrity: sha512-4FbRdAX+bSdmo4AUFuS0WNiPz8NgFt+r8ThgNWmlrjQjt1Q7ZR9+zTlce2859x4KSXrwIsaeTqDoKQmtP8pLmQ==}
     engines: {node: '>= 0.8'}
@@ -880,6 +978,14 @@ packages:
     resolution: {integrity: sha512-0KI/607xoxSToH7GjN1FfSbLoU0+btTicjsQSWQlh/hZykN8KpmMf7uYwPW3R+akZ6R/w18ZlXSHBYXiYUPO3g==}
     engines: {node: '>= 0.10'}
 
+  is-generator-function@1.1.2:
+    resolution: {integrity: sha512-upqt1SkGkODW9tsGNG5mtXTXtECizwtS2kA161M+gJPc1xdb/Ax629af6YrTwcOeQHbewrPNlE5Dx7kzvXTizA==}
+    engines: {node: '>= 0.4'}
+
+  is-regex@1.2.1:
+    resolution: {integrity: sha512-MjYsKHO5O7mCsmRGxWcLWheFqN9DJ/2TmngvjKXihe6efViPqc274+Fx/4fYj/r03+ESvBdTXK0V6tA3rgez1g==}
+    engines: {node: '>= 0.4'}
+
   is-stream@3.0.0:
     resolution: {integrity: sha512-LnQR4bZ9IADDRSkvpqMGvt/tEJWclzklNgSw48V5EAaAeDd6qGvN8ei6k5p0tvxSR171VmGyHuTiAOfxAbr8kA==}
     engines: {node: ^12.20.0 || ^14.13.1 || >=16.0.0}
@@ -893,6 +999,21 @@ packages:
 
   js-tokens@9.0.1:
     resolution: {integrity: sha512-mxa9E9ITFOt0ban3j6L5MpjwegGz6lBQmM1IJkWeBZGcMxto50+eWdjC/52xDbS2vy0k7vIMK0Fe2wfL9OQSpQ==}
+
+  keygrip@1.1.0:
+    resolution: {integrity: sha512-iYSchDJ+liQ8iwbSI2QqsQOvqv58eJCEanyJPJi+Khyu8smkcKSFUCbPwzFcL7YVtZ6eONjqRX/38caJ7QjRAQ==}
+    engines: {node: '>= 0.6'}
+
+  koa-compose@4.1.0:
+    resolution: {integrity: sha512-8ODW8TrDuMYvXRwra/Kh7/rJo9BtOfPc6qO8eAfC80CnCvSjSl0bkRM24X6/XBBEyj0v1nRUQ1LyOy3dbqOWXw==}
+
+  koa-convert@2.0.0:
+    resolution: {integrity: sha512-asOvN6bFlSnxewce2e/DK3p4tltyfC4VM7ZwuTuepI7dEQVcvpyFuBcEARu1+Hxg8DIwytce2n7jrZtRlPrARA==}
+    engines: {node: '>= 10'}
+
+  koa@2.16.4:
+    resolution: {integrity: sha512-3An0GCLDSR34tsCO4H8Tef8Pp2ngtaZDAZnsWJYelqXUK5wyiHvGItgK/xcSkmHLSTn1Jcho1mRQs2ehRzvKKw==}
+    engines: {node: ^4.8.4 || ^6.10.1 || ^7.10.1 || >= 8.1.4}
 
   lilconfig@3.1.3:
     resolution: {integrity: sha512-/vlFKAoH5Cgt3Ie+JLhRbwOsCQePABiU3tJ1egGvyQ+33R/vcwM2Zl2QR/LzjsBeItPt3oSVXapn+m4nQDvpzw==}
@@ -999,6 +1120,9 @@ packages:
     resolution: {integrity: sha512-1FlR+gjXK7X+AsAHso35MnyN5KqGwJRi/31ft6x0M194ht7S+rWAvd7PHss9xSKMzE0asv1pyIHaJYq+BbacAQ==}
     engines: {node: '>=12'}
 
+  only@0.0.2:
+    resolution: {integrity: sha512-Fvw+Jemq5fjjyWz6CpKx6w9s7xxqo3+JCyM0WXWeCSOboZ8ABkyvP8ID4CZuChA/wxSx+XSJmdOm8rGVyJ1hdQ==}
+
   p-limit@5.0.0:
     resolution: {integrity: sha512-/Eaoq+QyLSiXQ4lyYV23f14mZRQcXnxfHrN0vCai+ak9G0pp9iEQukIIZq5NccEvwRB8PUnZT0KsOoDCINS1qQ==}
     engines: {node: '>=18'}
@@ -1017,6 +1141,9 @@ packages:
 
   path-to-regexp@0.1.12:
     resolution: {integrity: sha512-RA1GjUVMnvYFxuqovrEqZoxxW5NUZqbwKtYz/Tt7nXerk0LbLblQmrsgdeOxV5SFHf0UDggjS/bSeOZwt1pmEQ==}
+
+  path-to-regexp@6.3.0:
+    resolution: {integrity: sha512-Yhpw4T9C6hPpgPeA28us07OJeqZ5EzQTkbfwuhsUg0c237RomFoETJgmp2sa3F/41gfLE6G5cqcYwznmeEeOlQ==}
 
   pathe@1.1.2:
     resolution: {integrity: sha512-whLdWMYL2TwI08hn8/ZqAbrVemu0LNaNNJZX73O6qaIdCTfXutsLhMkjdENX0qhsQ9uIimo4/aQOmXkoon2nDQ==}
@@ -1102,6 +1229,10 @@ packages:
   safe-buffer@5.2.1:
     resolution: {integrity: sha512-rp3So07KcdmmKbGvgaNxQSJr7bGVSVk5S9Eq1F+ppbRo70+YeaDxkw5Dd8NPN+GD6bjnYm2VuPuCXmpuYvmCXQ==}
 
+  safe-regex-test@1.1.0:
+    resolution: {integrity: sha512-x/+Cz4YrimQxQccJf5mKEbIa1NzeCRNI5Ecl/ekmlYaampdNLPalVyIcCZNNH3MvmqBugV5TMYZXv0ljslUlaw==}
+    engines: {node: '>= 0.4'}
+
   safer-buffer@2.1.2:
     resolution: {integrity: sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg==}
 
@@ -1157,6 +1288,10 @@ packages:
 
   stackback@0.0.2:
     resolution: {integrity: sha512-1XMJE5fQo1jGH6Y/7ebnwPOBEkIEnT4QF32d5R1+VXdXveM0IBMJt8zfaxX1P3QhVwrYe+576+jkANtSS2mBbw==}
+
+  statuses@1.5.0:
+    resolution: {integrity: sha512-OpZ3zP+jT1PI7I8nemJX4AKmAX070ZkYPVWV/AaKTJl+tXCTGyVdC1a4SL8RUQYEwk/f34ZX8UTykN68FwrqAA==}
+    engines: {node: '>= 0.6'}
 
   statuses@2.0.2:
     resolution: {integrity: sha512-DvEy55V3DB7uknRo+4iOGT5fP1slR8wQohVdknigZPMpMstaKJQWhwiYBACJE3Ul2pTnATihhBYnRhZQHGBiRw==}
@@ -1220,6 +1355,10 @@ packages:
 
   ts-interface-checker@0.1.13:
     resolution: {integrity: sha512-Y/arvbn+rrz3JCKl9C4kVNfTfSm2/mEp5FSz5EsZSANGPSlQrpRI5M4PKF+mJnE52jOO90PnPSc3Ur3bTQw0gA==}
+
+  tsscmp@1.0.6:
+    resolution: {integrity: sha512-LxhtAkPDTkVCMQjt2h6eBVY28KCjikZqZfMcC15YBeNjkgUpdCfBu5HoiOTDu86v6smE8yOjyEktJ8hlbANHQA==}
+    engines: {node: '>=0.6.x'}
 
   tsup@8.5.1:
     resolution: {integrity: sha512-xtgkqwdhpKWr3tKPmCkvYmS9xnQK3m3XgxZHwSUjvfTjp7YfXe5tT3GgWi0F2N+ZSMsOeWeZFh7ZZFg5iPhing==}
@@ -1344,6 +1483,10 @@ packages:
 
   wrappy@1.0.2:
     resolution: {integrity: sha512-l4Sp/DRseor9wL6EvV2+TuQn63dMkPjZ/sp9XkghTEbV9KlPS1xUsZ3u7/IQO4wxtcFB4bgpQPRcR3QCvezPcQ==}
+
+  ylru@1.4.0:
+    resolution: {integrity: sha512-2OQsPNEmBCvXuFlIni/a+Rn+R2pHW9INm0BxXJ4hVDA8TirqMj+J/Rp9ItLatT/5pZqWwefVrTQcHpixsxnVlA==}
+    engines: {node: '>= 4.0.0'}
 
   yocto-queue@1.2.2:
     resolution: {integrity: sha512-4LCcse/U2MHZ63HAJVE+v71o7yOdIe4cZ70Wpf8D/IyjDKYQLV5GD46B+hSTjJsvV5PztjvHoU580EftxjDZFQ==}
@@ -1516,6 +1659,15 @@ snapshots:
       '@jridgewell/resolve-uri': 3.1.2
       '@jridgewell/sourcemap-codec': 1.5.5
 
+  '@koa/router@13.1.1':
+    dependencies:
+      debug: 4.4.3
+      http-errors: 2.0.1
+      koa-compose: 4.1.0
+      path-to-regexp: 6.3.0
+    transitivePeerDependencies:
+      - supports-color
+
   '@noble/hashes@1.8.0': {}
 
   '@paralleldrive/cuid2@2.3.1':
@@ -1599,6 +1751,10 @@ snapshots:
 
   '@sinclair/typebox@0.27.10': {}
 
+  '@types/accepts@1.3.7':
+    dependencies:
+      '@types/node': 25.5.0
+
   '@types/body-parser@1.19.6':
     dependencies:
       '@types/connect': 3.4.38
@@ -1608,7 +1764,16 @@ snapshots:
     dependencies:
       '@types/node': 25.5.0
 
+  '@types/content-disposition@0.5.9': {}
+
   '@types/cookiejar@2.1.5': {}
+
+  '@types/cookies@0.9.2':
+    dependencies:
+      '@types/connect': 3.4.38
+      '@types/express': 4.17.25
+      '@types/keygrip': 1.0.6
+      '@types/node': 25.5.0
 
   '@types/estree@1.0.8': {}
 
@@ -1626,7 +1791,30 @@ snapshots:
       '@types/qs': 6.15.0
       '@types/serve-static': 1.15.10
 
+  '@types/http-assert@1.5.6': {}
+
   '@types/http-errors@2.0.5': {}
+
+  '@types/keygrip@1.0.6': {}
+
+  '@types/koa-compose@3.2.9':
+    dependencies:
+      '@types/koa': 2.15.0
+
+  '@types/koa@2.15.0':
+    dependencies:
+      '@types/accepts': 1.3.7
+      '@types/content-disposition': 0.5.9
+      '@types/cookies': 0.9.2
+      '@types/http-assert': 1.5.6
+      '@types/http-errors': 2.0.5
+      '@types/keygrip': 1.0.6
+      '@types/koa-compose': 3.2.9
+      '@types/node': 25.5.0
+
+  '@types/koa__router@12.0.5':
+    dependencies:
+      '@types/koa': 2.15.0
 
   '@types/methods@1.1.4': {}
 
@@ -1745,6 +1933,11 @@ snapshots:
 
   cac@6.7.14: {}
 
+  cache-content-type@1.0.1:
+    dependencies:
+      mime-types: 2.1.35
+      ylru: 1.4.0
+
   call-bind-apply-helpers@1.0.2:
     dependencies:
       es-errors: 1.3.0
@@ -1773,6 +1966,8 @@ snapshots:
     dependencies:
       readdirp: 4.1.2
 
+  co@4.6.0: {}
+
   combined-stream@1.0.8:
     dependencies:
       delayed-stream: 1.0.0
@@ -1799,6 +1994,11 @@ snapshots:
 
   cookiejar@2.1.4: {}
 
+  cookies@0.9.1:
+    dependencies:
+      depd: 2.0.0
+      keygrip: 1.1.0
+
   cross-spawn@7.0.6:
     dependencies:
       path-key: 3.1.1
@@ -1817,7 +2017,13 @@ snapshots:
     dependencies:
       type-detect: 4.1.0
 
+  deep-equal@1.0.1: {}
+
   delayed-stream@1.0.0: {}
+
+  delegates@1.0.0: {}
+
+  depd@1.1.2: {}
 
   depd@2.0.0: {}
 
@@ -1837,6 +2043,8 @@ snapshots:
       gopd: 1.2.0
 
   ee-first@1.1.1: {}
+
+  encodeurl@1.0.2: {}
 
   encodeurl@2.0.0: {}
 
@@ -2013,6 +2221,8 @@ snapshots:
 
   function-bind@1.1.2: {}
 
+  generator-function@2.0.1: {}
+
   get-func-name@2.0.2: {}
 
   get-intrinsic@1.3.0:
@@ -2047,6 +2257,19 @@ snapshots:
     dependencies:
       function-bind: 1.1.2
 
+  http-assert@1.5.0:
+    dependencies:
+      deep-equal: 1.0.1
+      http-errors: 1.8.1
+
+  http-errors@1.8.1:
+    dependencies:
+      depd: 1.1.2
+      inherits: 2.0.4
+      setprototypeof: 1.2.0
+      statuses: 1.5.0
+      toidentifier: 1.0.1
+
   http-errors@2.0.1:
     dependencies:
       depd: 2.0.0
@@ -2065,6 +2288,21 @@ snapshots:
 
   ipaddr.js@1.9.1: {}
 
+  is-generator-function@1.1.2:
+    dependencies:
+      call-bound: 1.0.4
+      generator-function: 2.0.1
+      get-proto: 1.0.1
+      has-tostringtag: 1.0.2
+      safe-regex-test: 1.1.0
+
+  is-regex@1.2.1:
+    dependencies:
+      call-bound: 1.0.4
+      gopd: 1.2.0
+      has-tostringtag: 1.0.2
+      hasown: 2.0.2
+
   is-stream@3.0.0: {}
 
   isexe@2.0.0: {}
@@ -2072,6 +2310,45 @@ snapshots:
   joycon@3.1.1: {}
 
   js-tokens@9.0.1: {}
+
+  keygrip@1.1.0:
+    dependencies:
+      tsscmp: 1.0.6
+
+  koa-compose@4.1.0: {}
+
+  koa-convert@2.0.0:
+    dependencies:
+      co: 4.6.0
+      koa-compose: 4.1.0
+
+  koa@2.16.4:
+    dependencies:
+      accepts: 1.3.8
+      cache-content-type: 1.0.1
+      content-disposition: 0.5.4
+      content-type: 1.0.5
+      cookies: 0.9.1
+      debug: 4.4.3
+      delegates: 1.0.0
+      depd: 2.0.0
+      destroy: 1.2.0
+      encodeurl: 1.0.2
+      escape-html: 1.0.3
+      fresh: 0.5.2
+      http-assert: 1.5.0
+      http-errors: 1.8.1
+      is-generator-function: 1.1.2
+      koa-compose: 4.1.0
+      koa-convert: 2.0.0
+      on-finished: 2.4.1
+      only: 0.0.2
+      parseurl: 1.3.3
+      statuses: 1.5.0
+      type-is: 1.6.18
+      vary: 1.1.2
+    transitivePeerDependencies:
+      - supports-color
 
   lilconfig@3.1.3: {}
 
@@ -2155,6 +2432,8 @@ snapshots:
     dependencies:
       mimic-fn: 4.0.0
 
+  only@0.0.2: {}
+
   p-limit@5.0.0:
     dependencies:
       yocto-queue: 1.2.2
@@ -2166,6 +2445,8 @@ snapshots:
   path-key@4.0.0: {}
 
   path-to-regexp@0.1.12: {}
+
+  path-to-regexp@6.3.0: {}
 
   pathe@1.1.2: {}
 
@@ -2260,6 +2541,12 @@ snapshots:
 
   safe-buffer@5.2.1: {}
 
+  safe-regex-test@1.1.0:
+    dependencies:
+      call-bound: 1.0.4
+      es-errors: 1.3.0
+      is-regex: 1.2.1
+
   safer-buffer@2.1.2: {}
 
   send@0.19.2:
@@ -2335,6 +2622,8 @@ snapshots:
 
   stackback@0.0.2: {}
 
+  statuses@1.5.0: {}
+
   statuses@2.0.2: {}
 
   std-env@3.10.0: {}
@@ -2403,6 +2692,8 @@ snapshots:
   tree-kill@1.2.2: {}
 
   ts-interface-checker@0.1.13: {}
+
+  tsscmp@1.0.6: {}
 
   tsup@8.5.1(postcss@8.5.8)(typescript@5.9.3):
     dependencies:
@@ -2522,5 +2813,7 @@ snapshots:
       stackback: 0.0.2
 
   wrappy@1.0.2: {}
+
+  ylru@1.4.0: {}
 
   yocto-queue@1.2.2: {}

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -5,6 +5,7 @@ export default defineConfig({
   resolve: {
     alias: {
       "@agent-layer/core": path.resolve(__dirname, "packages/core/src/index.ts"),
+      "@agent-layer/koa": path.resolve(__dirname, "packages/koa/src/index.ts"),
     },
   },
   test: {


### PR DESCRIPTION
## Summary

Adds `@agent-layer/koa` — Koa middleware equivalent of `@agent-layer/express`.

This unblocks Koa-based frameworks (including Strapi 4) from using agent-layer.

## What's included

Port of all Express middleware to Koa:

| Middleware | Description |
|---|---|
| `rateLimits()` | X-RateLimit-* headers, 429 on exceed |
| `agentErrors()` | Error-catching middleware + content-negotiated JSON/HTML |
| `notFoundHandler()` | 404 catch-all |
| `llmsTxtRoutes()` | /llms.txt and /llms-full.txt handlers |
| `agentMeta()` | HTML transform (data-agent-id, ARIA, meta tags) |
| `agentAuth()` | OAuth discovery + requireAuth middleware |
| `discoveryRoutes()` | /.well-known/ai and /openapi.json handlers |
| `agentLayer()` | One-liner composition via @koa/router |

## Design decisions

- All logic delegates to `@agent-layer/core` — zero duplication
- Uses Koa's `ctx` pattern throughout
- `agentLayer()` returns a `@koa/router` Router instance
- Package structure mirrors `@agent-layer/express` exactly

## Tests

41 new tests across 7 test files, all passing (136 total across repo).

## Usage

```ts
import Koa from "koa";
import { agentLayer } from "@agent-layer/koa";

const app = new Koa();
const router = agentLayer({
  rateLimit: { max: 100, windowMs: 60_000 },
  llmsTxt: { title: "My API", description: "REST API for widgets" },
  discovery: { manifest: { name: "My API", description: "REST API for widgets" } },
});

app.use(router.routes());
app.use(router.allowedMethods());
```