### PR TITLE
feat: add scoped API key authentication

### DIFF
--- a/packages/core/src/api-keys.test.ts
+++ b/packages/core/src/api-keys.test.ts
@@ -1,0 +1,214 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import {
+  MemoryApiKeyStore,
+  createApiKey,
+  validateApiKey,
+  hasScope,
+} from "./api-keys.js";
+import type { ScopedApiKey } from "./api-keys.js";
+
+describe("MemoryApiKeyStore", () => {
+  it("returns null for unknown keys", async () => {
+    const store = new MemoryApiKeyStore();
+    expect(await store.resolve("al_unknown")).toBeNull();
+  });
+
+  it("stores and resolves keys", async () => {
+    const store = new MemoryApiKeyStore();
+    const key: ScopedApiKey = {
+      keyId: "k1",
+      companyId: "c1",
+      userId: "u1",
+      scopes: ["read"],
+    };
+    store.set("al_abc123", key);
+    expect(await store.resolve("al_abc123")).toEqual(key);
+  });
+
+  it("deletes keys", async () => {
+    const store = new MemoryApiKeyStore();
+    const key: ScopedApiKey = {
+      keyId: "k1",
+      companyId: "c1",
+      userId: "u1",
+      scopes: ["read"],
+    };
+    store.set("al_abc123", key);
+    store.delete("al_abc123");
+    expect(await store.resolve("al_abc123")).toBeNull();
+  });
+
+  it("tracks size", async () => {
+    const store = new MemoryApiKeyStore();
+    expect(store.size).toBe(0);
+    store.set("al_k1", { keyId: "k1", companyId: "c1", userId: "u1", scopes: [] });
+    expect(store.size).toBe(1);
+    store.set("al_k2", { keyId: "k2", companyId: "c1", userId: "u1", scopes: [] });
+    expect(store.size).toBe(2);
+    store.delete("al_k1");
+    expect(store.size).toBe(1);
+  });
+});
+
+describe("createApiKey", () => {
+  it("generates a key with al_ prefix", () => {
+    const store = new MemoryApiKeyStore();
+    const { rawKey, key } = createApiKey(store, {
+      companyId: "c1",
+      userId: "u1",
+      scopes: ["read", "write"],
+    });
+
+    expect(rawKey).toMatch(/^al_[0-9a-f]{32}$/);
+    expect(key.companyId).toBe("c1");
+    expect(key.userId).toBe("u1");
+    expect(key.scopes).toEqual(["read", "write"]);
+    expect(key.keyId).toBeDefined();
+  });
+
+  it("stores the key so it can be resolved", async () => {
+    const store = new MemoryApiKeyStore();
+    const { rawKey, key } = createApiKey(store, {
+      companyId: "c1",
+      userId: "u1",
+      scopes: ["read"],
+    });
+
+    const resolved = await store.resolve(rawKey);
+    expect(resolved).toEqual(key);
+  });
+
+  it("includes optional expiresAt and metadata", () => {
+    const store = new MemoryApiKeyStore();
+    const expiresAt = new Date("2030-01-01");
+    const { key } = createApiKey(store, {
+      companyId: "c1",
+      userId: "u1",
+      scopes: ["read"],
+      expiresAt,
+      metadata: { tier: "premium" },
+    });
+
+    expect(key.expiresAt).toEqual(expiresAt);
+    expect(key.metadata).toEqual({ tier: "premium" });
+  });
+
+  it("omits expiresAt and metadata when not provided", () => {
+    const store = new MemoryApiKeyStore();
+    const { key } = createApiKey(store, {
+      companyId: "c1",
+      userId: "u1",
+      scopes: [],
+    });
+
+    expect(key.expiresAt).toBeUndefined();
+    expect(key.metadata).toBeUndefined();
+  });
+
+  it("generates unique keys each time", () => {
+    const store = new MemoryApiKeyStore();
+    const opts = { companyId: "c1", userId: "u1", scopes: ["read"] };
+    const { rawKey: k1 } = createApiKey(store, opts);
+    const { rawKey: k2 } = createApiKey(store, opts);
+    expect(k1).not.toBe(k2);
+  });
+});
+
+describe("validateApiKey", () => {
+  it("returns valid for a known, non-expired key", async () => {
+    const store = new MemoryApiKeyStore();
+    const { rawKey, key } = createApiKey(store, {
+      companyId: "c1",
+      userId: "u1",
+      scopes: ["read"],
+    });
+
+    const result = await validateApiKey(store, rawKey);
+    expect(result.valid).toBe(true);
+    expect(result.key).toEqual(key);
+    expect(result.error).toBeUndefined();
+  });
+
+  it("returns invalid for an unknown key", async () => {
+    const store = new MemoryApiKeyStore();
+    const result = await validateApiKey(store, "al_doesnotexist");
+    expect(result.valid).toBe(false);
+    expect(result.error).toBe("invalid_api_key");
+    expect(result.key).toBeUndefined();
+  });
+
+  it("returns invalid for an expired key", async () => {
+    vi.useFakeTimers();
+    const store = new MemoryApiKeyStore();
+    const { rawKey } = createApiKey(store, {
+      companyId: "c1",
+      userId: "u1",
+      scopes: ["read"],
+      expiresAt: new Date(Date.now() + 1000),
+    });
+
+    // Before expiry — valid
+    const before = await validateApiKey(store, rawKey);
+    expect(before.valid).toBe(true);
+
+    // After expiry — invalid
+    vi.advanceTimersByTime(1001);
+    const after = await validateApiKey(store, rawKey);
+    expect(after.valid).toBe(false);
+    expect(after.error).toBe("api_key_expired");
+
+    vi.useRealTimers();
+  });
+
+  it("returns valid for a key with no expiry", async () => {
+    const store = new MemoryApiKeyStore();
+    const { rawKey } = createApiKey(store, {
+      companyId: "c1",
+      userId: "u1",
+      scopes: ["read"],
+    });
+
+    const result = await validateApiKey(store, rawKey);
+    expect(result.valid).toBe(true);
+  });
+});
+
+describe("hasScope", () => {
+  const key: ScopedApiKey = {
+    keyId: "k1",
+    companyId: "c1",
+    userId: "u1",
+    scopes: ["read", "write"],
+  };
+
+  it("returns true for a single matching scope", () => {
+    expect(hasScope(key, "read")).toBe(true);
+  });
+
+  it("returns false for a single non-matching scope", () => {
+    expect(hasScope(key, "admin")).toBe(false);
+  });
+
+  it("returns true when all required scopes match", () => {
+    expect(hasScope(key, ["read", "write"])).toBe(true);
+  });
+
+  it("returns false when some required scopes are missing", () => {
+    expect(hasScope(key, ["read", "admin"])).toBe(false);
+  });
+
+  it("returns true for wildcard scope", () => {
+    const wildcardKey: ScopedApiKey = {
+      keyId: "k2",
+      companyId: "c1",
+      userId: "u1",
+      scopes: ["*"],
+    };
+    expect(hasScope(wildcardKey, "anything")).toBe(true);
+    expect(hasScope(wildcardKey, ["read", "write", "admin"])).toBe(true);
+  });
+
+  it("returns true for empty required scopes array", () => {
+    expect(hasScope(key, [])).toBe(true);
+  });
+});

--- a/packages/core/src/api-keys.ts
+++ b/packages/core/src/api-keys.ts
@@ -1,0 +1,143 @@
+// ── Types ───────────────────────────────────────────────────────────────
+
+export interface ScopedApiKey {
+  keyId: string;
+  companyId: string;
+  userId: string;
+  scopes: string[];
+  expiresAt?: Date;
+  metadata?: Record<string, unknown>;
+}
+
+export interface ApiKeyStore {
+  /** Resolve a raw API key string to a ScopedApiKey, or null if not found. */
+  resolve(rawKey: string): Promise<ScopedApiKey | null>;
+}
+
+export interface ApiKeyValidationResult {
+  valid: boolean;
+  key?: ScopedApiKey;
+  error?: string;
+}
+
+export interface CreateApiKeyOptions {
+  companyId: string;
+  userId: string;
+  scopes: string[];
+  expiresAt?: Date;
+  metadata?: Record<string, unknown>;
+}
+
+export interface CreateApiKeyResult {
+  rawKey: string;
+  key: ScopedApiKey;
+}
+
+// ── MemoryApiKeyStore ───────────────────────────────────────────────────
+
+/**
+ * In-memory API key store for development and testing.
+ */
+export class MemoryApiKeyStore implements ApiKeyStore {
+  private keys = new Map<string, ScopedApiKey>();
+
+  async resolve(rawKey: string): Promise<ScopedApiKey | null> {
+    return this.keys.get(rawKey) ?? null;
+  }
+
+  /** Store a key mapping. Used internally by createApiKey. */
+  set(rawKey: string, key: ScopedApiKey): void {
+    this.keys.set(rawKey, key);
+  }
+
+  /** Remove a key mapping. */
+  delete(rawKey: string): void {
+    this.keys.delete(rawKey);
+  }
+
+  /** Number of stored keys. */
+  get size(): number {
+    return this.keys.size;
+  }
+}
+
+// ── Key generation ──────────────────────────────────────────────────────
+
+/** Convert a Uint8Array to a hex string. */
+function toHex(bytes: Uint8Array): string {
+  return Array.from(bytes, (b) => b.toString(16).padStart(2, "0")).join("");
+}
+
+/** Generate cryptographically random hex string of the given byte length. */
+function randomHex(byteLength: number): string {
+  const bytes = new Uint8Array(byteLength);
+  // globalThis.crypto is available in Node 18+ and all modern browsers
+  (globalThis as any).crypto.getRandomValues(bytes);
+  return toHex(bytes);
+}
+
+/**
+ * Generate a new scoped API key and store it.
+ * Key format: `al_` prefix + 32 random hex characters.
+ */
+export function createApiKey(
+  store: MemoryApiKeyStore,
+  opts: CreateApiKeyOptions,
+): CreateApiKeyResult {
+  const rawKey = `al_${randomHex(16)}`;
+  const keyId = randomHex(8);
+
+  const key: ScopedApiKey = {
+    keyId,
+    companyId: opts.companyId,
+    userId: opts.userId,
+    scopes: opts.scopes,
+    ...(opts.expiresAt != null && { expiresAt: opts.expiresAt }),
+    ...(opts.metadata != null && { metadata: opts.metadata }),
+  };
+
+  store.set(rawKey, key);
+
+  return { rawKey, key };
+}
+
+// ── Validation ──────────────────────────────────────────────────────────
+
+/**
+ * Validate a raw API key string against a store.
+ * Checks existence and expiry.
+ */
+export async function validateApiKey(
+  store: ApiKeyStore,
+  rawKey: string,
+): Promise<ApiKeyValidationResult> {
+  const key = await store.resolve(rawKey);
+
+  if (!key) {
+    return { valid: false, error: "invalid_api_key" };
+  }
+
+  if (key.expiresAt && key.expiresAt.getTime() <= Date.now()) {
+    return { valid: false, error: "api_key_expired" };
+  }
+
+  return { valid: true, key };
+}
+
+// ── Scope checking ──────────────────────────────────────────────────────
+
+/**
+ * Check if a scoped API key has the required scope(s).
+ * Supports wildcard `*` which grants all scopes.
+ */
+export function hasScope(
+  key: ScopedApiKey,
+  required: string | string[],
+): boolean {
+  if (key.scopes.includes("*")) {
+    return true;
+  }
+
+  const requiredScopes = Array.isArray(required) ? required : [required];
+  return requiredScopes.every((scope) => key.scopes.includes(scope));
+}

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -2,6 +2,12 @@ export { formatError, AgentError, notFoundError, rateLimitError } from "./errors
 export { MemoryStore, createRateLimiter } from "./rate-limit.js";
 export { generateLlmsTxt, generateLlmsFullTxt } from "./llms-txt.js";
 export { generateAIManifest, generateJsonLd } from "./discovery.js";
+export {
+  MemoryApiKeyStore,
+  createApiKey,
+  validateApiKey,
+  hasScope,
+} from "./api-keys.js";
 export type {
   AgentErrorEnvelope,
   AgentErrorOptions,
@@ -17,5 +23,11 @@ export type {
   DiscoveryConfig,
   AgentMetaConfig,
   AgentAuthConfig,
+  ApiKeyConfig,
+  ScopedApiKey,
+  ApiKeyStore,
+  ApiKeyValidationResult,
+  CreateApiKeyOptions,
+  CreateApiKeyResult,
   AgentLayerConfig,
 } from "./types.js";

--- a/packages/core/src/types.ts
+++ b/packages/core/src/types.ts
@@ -129,6 +129,16 @@ export interface AgentMetaConfig {
   metaTags?: Record<string, string>;
 }
 
+// ── API Keys ─────────────────────────────────────────────────────────────
+
+export type { ScopedApiKey, ApiKeyStore, ApiKeyValidationResult, CreateApiKeyOptions, CreateApiKeyResult } from "./api-keys.js";
+
+export interface ApiKeyConfig {
+  store: import("./api-keys.js").ApiKeyStore;
+  /** Header name to extract the API key from. Default: "X-Agent-Key". */
+  headerName?: string;
+}
+
 // ── Agent Auth ───────────────────────────────────────────────────────────
 
 export interface AgentAuthConfig {
@@ -153,4 +163,5 @@ export interface AgentLayerConfig {
   discovery?: false | DiscoveryConfig;
   agentMeta?: false | AgentMetaConfig;
   agentAuth?: false | AgentAuthConfig;
+  apiKeys?: false | ApiKeyConfig;
 }

--- a/packages/express/src/api-keys.test.ts
+++ b/packages/express/src/api-keys.test.ts
@@ -1,0 +1,207 @@
+import { describe, it, expect, vi } from "vitest";
+import { MemoryApiKeyStore, createApiKey } from "@agent-layer/core";
+import { apiKeyAuth, requireScope } from "./api-keys.js";
+
+function mockReq(overrides: Record<string, unknown> = {}): any {
+  return { headers: {}, ...overrides };
+}
+
+function mockRes(): any {
+  const res: any = {
+    statusCode: 200,
+    headers: {} as Record<string, string>,
+    body: null as unknown,
+    status(code: number) {
+      res.statusCode = code;
+      return res;
+    },
+    json(data: unknown) {
+      res.body = data;
+      return res;
+    },
+    setHeader(key: string, val: string) {
+      res.headers[key.toLowerCase()] = val;
+      return res;
+    },
+    getHeader(key: string) {
+      return res.headers[key.toLowerCase()];
+    },
+  };
+  return res;
+}
+
+describe("apiKeyAuth middleware", () => {
+  it("returns 401 when header is missing", async () => {
+    const store = new MemoryApiKeyStore();
+    const middleware = apiKeyAuth({ store });
+    const req = mockReq();
+    const res = mockRes();
+    const next = vi.fn();
+
+    await middleware(req, res, next);
+
+    expect(res.statusCode).toBe(401);
+    expect(res.body.error.code).toBe("api_key_missing");
+    expect(next).not.toHaveBeenCalled();
+  });
+
+  it("returns 401 for an invalid key", async () => {
+    const store = new MemoryApiKeyStore();
+    const middleware = apiKeyAuth({ store });
+    const req = mockReq({ headers: { "x-agent-key": "al_bogus" } });
+    const res = mockRes();
+    const next = vi.fn();
+
+    await middleware(req, res, next);
+
+    expect(res.statusCode).toBe(401);
+    expect(res.body.error.code).toBe("invalid_api_key");
+    expect(next).not.toHaveBeenCalled();
+  });
+
+  it("returns 401 for an expired key", async () => {
+    vi.useFakeTimers();
+    const store = new MemoryApiKeyStore();
+    const { rawKey } = createApiKey(store, {
+      companyId: "c1",
+      userId: "u1",
+      scopes: ["read"],
+      expiresAt: new Date(Date.now() + 1000),
+    });
+
+    vi.advanceTimersByTime(1001);
+
+    const middleware = apiKeyAuth({ store });
+    const req = mockReq({ headers: { "x-agent-key": rawKey } });
+    const res = mockRes();
+    const next = vi.fn();
+
+    await middleware(req, res, next);
+
+    expect(res.statusCode).toBe(401);
+    expect(res.body.error.code).toBe("api_key_expired");
+    expect(next).not.toHaveBeenCalled();
+    vi.useRealTimers();
+  });
+
+  it("attaches agentKey and calls next for valid key", async () => {
+    const store = new MemoryApiKeyStore();
+    const { rawKey, key } = createApiKey(store, {
+      companyId: "c1",
+      userId: "u1",
+      scopes: ["read"],
+    });
+
+    const middleware = apiKeyAuth({ store });
+    const req = mockReq({ headers: { "x-agent-key": rawKey } });
+    const res = mockRes();
+    const next = vi.fn();
+
+    await middleware(req, res, next);
+
+    expect(req.agentKey).toEqual(key);
+    expect(next).toHaveBeenCalled();
+  });
+
+  it("uses custom header name", async () => {
+    const store = new MemoryApiKeyStore();
+    const { rawKey } = createApiKey(store, {
+      companyId: "c1",
+      userId: "u1",
+      scopes: ["read"],
+    });
+
+    const middleware = apiKeyAuth({ store, headerName: "Authorization" });
+    const req = mockReq({ headers: { authorization: rawKey } });
+    const res = mockRes();
+    const next = vi.fn();
+
+    await middleware(req, res, next);
+
+    expect(next).toHaveBeenCalled();
+  });
+
+  it("passes store errors to next", async () => {
+    const errorStore = {
+      resolve: async () => { throw new Error("store error"); },
+    };
+    const middleware = apiKeyAuth({ store: errorStore });
+    const req = mockReq({ headers: { "x-agent-key": "al_anything" } });
+    const res = mockRes();
+    const next = vi.fn();
+
+    await middleware(req, res, next);
+
+    expect(next).toHaveBeenCalledWith(expect.any(Error));
+  });
+});
+
+describe("requireScope middleware", () => {
+  it("returns 401 when no agentKey is present", () => {
+    const middleware = requireScope("read");
+    const req = mockReq();
+    const res = mockRes();
+    const next = vi.fn();
+
+    middleware(req, res, next);
+
+    expect(res.statusCode).toBe(401);
+    expect(res.body.error.code).toBe("api_key_missing");
+    expect(next).not.toHaveBeenCalled();
+  });
+
+  it("returns 403 when scope is insufficient", () => {
+    const middleware = requireScope("admin");
+    const req = mockReq({
+      agentKey: { keyId: "k1", companyId: "c1", userId: "u1", scopes: ["read"] },
+    });
+    const res = mockRes();
+    const next = vi.fn();
+
+    middleware(req, res, next);
+
+    expect(res.statusCode).toBe(403);
+    expect(res.body.error.code).toBe("insufficient_scope");
+    expect(next).not.toHaveBeenCalled();
+  });
+
+  it("calls next when scope matches", () => {
+    const middleware = requireScope("read");
+    const req = mockReq({
+      agentKey: { keyId: "k1", companyId: "c1", userId: "u1", scopes: ["read", "write"] },
+    });
+    const res = mockRes();
+    const next = vi.fn();
+
+    middleware(req, res, next);
+
+    expect(next).toHaveBeenCalled();
+  });
+
+  it("calls next with wildcard scope", () => {
+    const middleware = requireScope(["read", "write", "admin"]);
+    const req = mockReq({
+      agentKey: { keyId: "k1", companyId: "c1", userId: "u1", scopes: ["*"] },
+    });
+    const res = mockRes();
+    const next = vi.fn();
+
+    middleware(req, res, next);
+
+    expect(next).toHaveBeenCalled();
+  });
+
+  it("checks multiple required scopes", () => {
+    const middleware = requireScope(["read", "write"]);
+    const req = mockReq({
+      agentKey: { keyId: "k1", companyId: "c1", userId: "u1", scopes: ["read"] },
+    });
+    const res = mockRes();
+    const next = vi.fn();
+
+    middleware(req, res, next);
+
+    expect(res.statusCode).toBe(403);
+    expect(res.body.error.code).toBe("insufficient_scope");
+  });
+});

--- a/packages/express/src/api-keys.ts
+++ b/packages/express/src/api-keys.ts
@@ -1,0 +1,96 @@
+import type { Request, Response, NextFunction } from "express";
+import { formatError, validateApiKey, hasScope } from "@agent-layer/core";
+import type { ApiKeyConfig, ScopedApiKey } from "@agent-layer/core";
+
+declare global {
+  namespace Express {
+    interface Request {
+      agentKey?: ScopedApiKey;
+    }
+  }
+}
+
+/**
+ * Express middleware that extracts and validates an API key from a request header.
+ * Attaches the resolved key to `req.agentKey` on success.
+ */
+export function apiKeyAuth(config: ApiKeyConfig) {
+  const headerName = config.headerName ?? "X-Agent-Key";
+  const headerLower = headerName.toLowerCase();
+
+  return async function apiKeyAuthMiddleware(
+    req: Request,
+    res: Response,
+    next: NextFunction,
+  ): Promise<void> {
+    try {
+      const rawKey = req.headers[headerLower] as string | undefined;
+
+      if (!rawKey) {
+        const envelope = formatError({
+          code: "api_key_missing",
+          message: `Missing required header: ${headerName}`,
+          status: 401,
+        });
+        res.status(401).json({ error: envelope });
+        return;
+      }
+
+      const result = await validateApiKey(config.store, rawKey);
+
+      if (!result.valid) {
+        const status = result.error === "api_key_expired" ? 401 : 401;
+        const envelope = formatError({
+          code: result.error!,
+          message:
+            result.error === "api_key_expired"
+              ? "The API key has expired."
+              : "The API key is invalid.",
+          status,
+        });
+        res.status(status).json({ error: envelope });
+        return;
+      }
+
+      req.agentKey = result.key;
+      next();
+    } catch (err) {
+      next(err);
+    }
+  };
+}
+
+/**
+ * Express middleware that checks if the authenticated API key has the required scope(s).
+ * Must be used after `apiKeyAuth()`.
+ */
+export function requireScope(scope: string | string[]) {
+  return function requireScopeMiddleware(
+    req: Request,
+    res: Response,
+    next: NextFunction,
+  ): void {
+    if (!req.agentKey) {
+      const envelope = formatError({
+        code: "api_key_missing",
+        message: "Authentication required before scope check.",
+        status: 401,
+      });
+      res.status(401).json({ error: envelope });
+      return;
+    }
+
+    if (!hasScope(req.agentKey, scope)) {
+      const required = Array.isArray(scope) ? scope.join(", ") : scope;
+      const envelope = formatError({
+        code: "insufficient_scope",
+        message: `Required scope(s): ${required}`,
+        status: 403,
+      });
+      res.status(403).json({ error: envelope });
+      return;
+    }
+
+    next();
+  };
+}

--- a/packages/express/src/index.ts
+++ b/packages/express/src/index.ts
@@ -7,6 +7,7 @@ import { llmsTxtRoutes } from "./llms-txt.js";
 import { discoveryRoutes } from "./discovery.js";
 import { agentMeta } from "./agent-meta.js";
 import { agentAuth } from "./agent-auth.js";
+import { apiKeyAuth } from "./api-keys.js";
 
 export { agentErrors, notFoundHandler } from "./agent-errors.js";
 export { rateLimits } from "./rate-limits.js";
@@ -14,6 +15,7 @@ export { llmsTxtRoutes } from "./llms-txt.js";
 export { discoveryRoutes } from "./discovery.js";
 export { agentMeta } from "./agent-meta.js";
 export { agentAuth } from "./agent-auth.js";
+export { apiKeyAuth, requireScope } from "./api-keys.js";
 
 /**
  * One-liner that composes all agent-layer middleware onto a single Express router.
@@ -21,6 +23,11 @@ export { agentAuth } from "./agent-auth.js";
  */
 export function agentLayer(config: AgentLayerConfig): Router {
   const router = createRouter();
+
+  // API key auth (earliest — before rate limiting)
+  if (config.apiKeys !== false && config.apiKeys) {
+    router.use(apiKeyAuth(config.apiKeys));
+  }
 
   // Rate limiting (early — before routes)
   if (config.rateLimit !== false && config.rateLimit) {

--- a/packages/koa/src/api-keys.test.ts
+++ b/packages/koa/src/api-keys.test.ts
@@ -1,0 +1,191 @@
+import { describe, it, expect, vi } from "vitest";
+import { MemoryApiKeyStore, createApiKey } from "@agent-layer/core";
+import { apiKeyAuth, requireScope } from "./api-keys.js";
+
+function mockCtx(overrides: Record<string, unknown> = {}): any {
+  const headers: Record<string, string> = {};
+  return {
+    request: { headers: {}, ...overrides },
+    headers: (overrides.headers as Record<string, string>) ?? {},
+    state: (overrides.state as Record<string, unknown>) ?? {},
+    status: 200,
+    body: null as unknown,
+    _headers: headers,
+    set(key: string, val: string) {
+      headers[key.toLowerCase()] = val;
+    },
+    get response() {
+      return { headers };
+    },
+  };
+}
+
+describe("apiKeyAuth middleware", () => {
+  it("returns 401 when header is missing", async () => {
+    const store = new MemoryApiKeyStore();
+    const middleware = apiKeyAuth({ store });
+    const ctx = mockCtx();
+    const next = vi.fn();
+
+    await middleware(ctx, next);
+
+    expect(ctx.status).toBe(401);
+    expect(ctx.body.error.code).toBe("api_key_missing");
+    expect(next).not.toHaveBeenCalled();
+  });
+
+  it("returns 401 for an invalid key", async () => {
+    const store = new MemoryApiKeyStore();
+    const middleware = apiKeyAuth({ store });
+    const ctx = mockCtx({ headers: { "x-agent-key": "al_bogus" } });
+    const next = vi.fn();
+
+    await middleware(ctx, next);
+
+    expect(ctx.status).toBe(401);
+    expect(ctx.body.error.code).toBe("invalid_api_key");
+    expect(next).not.toHaveBeenCalled();
+  });
+
+  it("returns 401 for an expired key", async () => {
+    vi.useFakeTimers();
+    const store = new MemoryApiKeyStore();
+    const { rawKey } = createApiKey(store, {
+      companyId: "c1",
+      userId: "u1",
+      scopes: ["read"],
+      expiresAt: new Date(Date.now() + 1000),
+    });
+
+    vi.advanceTimersByTime(1001);
+
+    const middleware = apiKeyAuth({ store });
+    const ctx = mockCtx({ headers: { "x-agent-key": rawKey } });
+    const next = vi.fn();
+
+    await middleware(ctx, next);
+
+    expect(ctx.status).toBe(401);
+    expect(ctx.body.error.code).toBe("api_key_expired");
+    expect(next).not.toHaveBeenCalled();
+    vi.useRealTimers();
+  });
+
+  it("attaches agentKey to state and calls next for valid key", async () => {
+    const store = new MemoryApiKeyStore();
+    const { rawKey, key } = createApiKey(store, {
+      companyId: "c1",
+      userId: "u1",
+      scopes: ["read"],
+    });
+
+    const middleware = apiKeyAuth({ store });
+    const ctx = mockCtx({ headers: { "x-agent-key": rawKey } });
+    const next = vi.fn();
+
+    await middleware(ctx, next);
+
+    expect(ctx.state.agentKey).toEqual(key);
+    expect(next).toHaveBeenCalled();
+  });
+
+  it("uses custom header name", async () => {
+    const store = new MemoryApiKeyStore();
+    const { rawKey } = createApiKey(store, {
+      companyId: "c1",
+      userId: "u1",
+      scopes: ["read"],
+    });
+
+    const middleware = apiKeyAuth({ store, headerName: "Authorization" });
+    const ctx = mockCtx({ headers: { authorization: rawKey } });
+    const next = vi.fn();
+
+    await middleware(ctx, next);
+
+    expect(next).toHaveBeenCalled();
+  });
+
+  it("propagates store errors", async () => {
+    const errorStore = {
+      resolve: async () => { throw new Error("store error"); },
+    };
+    const middleware = apiKeyAuth({ store: errorStore });
+    const ctx = mockCtx({ headers: { "x-agent-key": "al_anything" } });
+
+    await expect(middleware(ctx, vi.fn())).rejects.toThrow("store error");
+  });
+});
+
+describe("requireScope middleware", () => {
+  it("returns 401 when no agentKey is present", async () => {
+    const middleware = requireScope("read");
+    const ctx = mockCtx();
+    const next = vi.fn();
+
+    await middleware(ctx, next);
+
+    expect(ctx.status).toBe(401);
+    expect(ctx.body.error.code).toBe("api_key_missing");
+    expect(next).not.toHaveBeenCalled();
+  });
+
+  it("returns 403 when scope is insufficient", async () => {
+    const middleware = requireScope("admin");
+    const ctx = mockCtx({
+      state: {
+        agentKey: { keyId: "k1", companyId: "c1", userId: "u1", scopes: ["read"] },
+      },
+    });
+    const next = vi.fn();
+
+    await middleware(ctx, next);
+
+    expect(ctx.status).toBe(403);
+    expect(ctx.body.error.code).toBe("insufficient_scope");
+    expect(next).not.toHaveBeenCalled();
+  });
+
+  it("calls next when scope matches", async () => {
+    const middleware = requireScope("read");
+    const ctx = mockCtx({
+      state: {
+        agentKey: { keyId: "k1", companyId: "c1", userId: "u1", scopes: ["read", "write"] },
+      },
+    });
+    const next = vi.fn();
+
+    await middleware(ctx, next);
+
+    expect(next).toHaveBeenCalled();
+  });
+
+  it("calls next with wildcard scope", async () => {
+    const middleware = requireScope(["read", "write", "admin"]);
+    const ctx = mockCtx({
+      state: {
+        agentKey: { keyId: "k1", companyId: "c1", userId: "u1", scopes: ["*"] },
+      },
+    });
+    const next = vi.fn();
+
+    await middleware(ctx, next);
+
+    expect(next).toHaveBeenCalled();
+  });
+
+  it("checks multiple required scopes", async () => {
+    const middleware = requireScope(["read", "write"]);
+    const ctx = mockCtx({
+      state: {
+        agentKey: { keyId: "k1", companyId: "c1", userId: "u1", scopes: ["read"] },
+      },
+    });
+    const next = vi.fn();
+
+    await middleware(ctx, next);
+
+    expect(ctx.status).toBe(403);
+    expect(ctx.body.error.code).toBe("insufficient_scope");
+  });
+});

--- a/packages/koa/src/api-keys.ts
+++ b/packages/koa/src/api-keys.ts
@@ -1,0 +1,92 @@
+import type { Context, Next } from "koa";
+import { formatError, validateApiKey, hasScope } from "@agent-layer/core";
+import type { ApiKeyConfig, ScopedApiKey } from "@agent-layer/core";
+
+// Augment Koa state to include agentKey
+declare module "koa" {
+  interface DefaultState {
+    agentKey?: ScopedApiKey;
+  }
+}
+
+/**
+ * Koa middleware that extracts and validates an API key from a request header.
+ * Attaches the resolved key to `ctx.state.agentKey` on success.
+ */
+export function apiKeyAuth(config: ApiKeyConfig) {
+  const headerName = config.headerName ?? "X-Agent-Key";
+  const headerLower = headerName.toLowerCase();
+
+  return async function apiKeyAuthMiddleware(
+    ctx: Context,
+    next: Next,
+  ): Promise<void> {
+    const rawKey = ctx.headers[headerLower] as string | undefined;
+
+    if (!rawKey) {
+      const envelope = formatError({
+        code: "api_key_missing",
+        message: `Missing required header: ${headerName}`,
+        status: 401,
+      });
+      ctx.status = 401;
+      ctx.body = { error: envelope };
+      return;
+    }
+
+    const result = await validateApiKey(config.store, rawKey);
+
+    if (!result.valid) {
+      const envelope = formatError({
+        code: result.error!,
+        message:
+          result.error === "api_key_expired"
+            ? "The API key has expired."
+            : "The API key is invalid.",
+        status: 401,
+      });
+      ctx.status = 401;
+      ctx.body = { error: envelope };
+      return;
+    }
+
+    ctx.state.agentKey = result.key;
+    await next();
+  };
+}
+
+/**
+ * Koa middleware that checks if the authenticated API key has the required scope(s).
+ * Must be used after `apiKeyAuth()`.
+ */
+export function requireScope(scope: string | string[]) {
+  return async function requireScopeMiddleware(
+    ctx: Context,
+    next: Next,
+  ): Promise<void> {
+    if (!ctx.state.agentKey) {
+      const envelope = formatError({
+        code: "api_key_missing",
+        message: "Authentication required before scope check.",
+        status: 401,
+      });
+      ctx.status = 401;
+      ctx.body = { error: envelope };
+      return;
+    }
+
+    if (!hasScope(ctx.state.agentKey, scope)) {
+      const required = Array.isArray(scope) ? scope.join(", ") : scope;
+      const envelope = formatError({
+        code: "insufficient_scope",
+        message: `Required scope(s): ${required}`,
+        status: 403,
+      });
+      ctx.status = 403;
+      ctx.body = { error: envelope };
+      return;
+    }
+
+    await next();
+  };
+}

--- a/packages/koa/src/index.ts
+++ b/packages/koa/src/index.ts
@@ -6,6 +6,7 @@ import { llmsTxtRoutes } from "./llms-txt.js";
 import { discoveryRoutes } from "./discovery.js";
 import { agentMeta } from "./agent-meta.js";
 import { agentAuth } from "./agent-auth.js";
+import { apiKeyAuth } from "./api-keys.js";
 
 export { agentErrors, notFoundHandler } from "./agent-errors.js";
 export { rateLimits } from "./rate-limits.js";
@@ -13,6 +14,7 @@ export { llmsTxtRoutes } from "./llms-txt.js";
 export { discoveryRoutes } from "./discovery.js";
 export { agentMeta } from "./agent-meta.js";
 export { agentAuth } from "./agent-auth.js";
+export { apiKeyAuth, requireScope } from "./api-keys.js";
 
 /**
  * One-liner that composes all agent-layer middleware onto a single Koa Router.
@@ -20,6 +22,11 @@ export { agentAuth } from "./agent-auth.js";
  */
 export function agentLayer(config: AgentLayerConfig): Router {
   const router = new Router();
+
+  // API key auth (earliest — before rate limiting)
+  if (config.apiKeys !== false && config.apiKeys) {
+    router.use(apiKeyAuth(config.apiKeys));
+  }
 
   // Rate limiting (early — before routes)
   if (config.rateLimit !== false && config.rateLimit) {


### PR DESCRIPTION
## Summary

Adds scoped API key support across core, express, and koa packages. This is the security foundation for agent authentication — agents authenticate with scoped keys rather than user tokens.

## What's included

### `@agent-layer/core`
- `ScopedApiKey` interface: `keyId`, `companyId`, `userId`, `scopes[]`, `expiresAt?`, `metadata?`
- `ApiKeyStore` interface (pluggable) + `MemoryApiKeyStore` for dev/testing
- `createApiKey()` — generate keys with `al_` prefix + random hex
- `validateApiKey()` — resolve + expiry check
- `hasScope()` — scope checking with wildcard `*` support
- `ApiKeyConfig` added to `AgentLayerConfig`

### `@agent-layer/express`
- `apiKeyAuth(config)` — middleware extracting key from header, validating, attaching `req.agentKey`
- `requireScope(scope)` — middleware checking scopes on `req.agentKey`
- 401 for missing/invalid/expired, 403 for insufficient scope
- Wired into `agentLayer()` composition (before rate limiting)

### `@agent-layer/koa`
- Same as express but for Koa (`ctx.state.agentKey`)
- Same middleware pattern and error responses

## Key design decisions
- **Pluggable store**: Apps bring their own persistence (Redis, DB, etc.) via `ApiKeyStore` interface
- **Company-scoped**: Every key is tied to a `companyId` — enables multi-tenant isolation
- **Wildcard scope**: `*` grants all permissions (for admin keys)
- **Key format**: `al_` prefix makes keys easy to identify and rotate

## Tests
41 new tests (19 core + 11 express + 11 koa), all passing. 177 total across repo.

## Usage

```ts
import { MemoryApiKeyStore, createApiKey } from "@agent-layer/core";
import { apiKeyAuth, requireScope } from "@agent-layer/express";

const store = new MemoryApiKeyStore();
const { rawKey } = await createApiKey(store, {
  companyId: "acme",
  userId: "user-123",
  scopes: ["shifts:read", "postings:read"],
});

// Protect routes
app.use(apiKeyAuth({ store }));
app.get("/api/shifts", requireScope("shifts:read"), listShifts);
```