### PR TITLE
feat: A2A Agent Card — /.well-known/agent.json endpoint per Google A2A protocol

### DIFF
--- a/packages/core/src/a2a.test.ts
+++ b/packages/core/src/a2a.test.ts
@@ -1,0 +1,125 @@
+import { describe, it, expect } from "vitest";
+import { generateAgentCard, validateAgentCard } from "./a2a.js";
+import type { A2AConfig, A2AAgentCard } from "./a2a.js";
+
+const minimalConfig: A2AConfig = {
+  card: {
+    protocolVersion: "1.0.0",
+    name: "test-agent",
+    url: "https://example.com/agent",
+    skills: [
+      { id: "search", name: "Web Search", description: "Search the web" },
+    ],
+  },
+};
+
+describe("generateAgentCard", () => {
+  it("returns a valid agent card from minimal config", () => {
+    const card = generateAgentCard(minimalConfig);
+    expect(card.name).toBe("test-agent");
+    expect(card.url).toBe("https://example.com/agent");
+    expect(card.protocolVersion).toBe("1.0.0");
+    expect(card.skills).toHaveLength(1);
+    expect(card.skills[0].id).toBe("search");
+  });
+
+  it("sets default input/output modes to text/plain", () => {
+    const card = generateAgentCard(minimalConfig);
+    expect(card.defaultInputModes).toEqual(["text/plain"]);
+    expect(card.defaultOutputModes).toEqual(["text/plain"]);
+  });
+
+  it("preserves custom input/output modes", () => {
+    const card = generateAgentCard({
+      card: {
+        ...minimalConfig.card,
+        defaultInputModes: ["application/json"],
+        defaultOutputModes: ["application/json", "text/plain"],
+      },
+    });
+    expect(card.defaultInputModes).toEqual(["application/json"]);
+    expect(card.defaultOutputModes).toEqual(["application/json", "text/plain"]);
+  });
+
+  it("defaults protocolVersion to 1.0.0 when omitted", () => {
+    const card = generateAgentCard({
+      card: { ...minimalConfig.card, protocolVersion: "" as any },
+    });
+    expect(card.protocolVersion).toBe("1.0.0");
+  });
+
+  it("includes optional fields when provided", () => {
+    const card = generateAgentCard({
+      card: {
+        ...minimalConfig.card,
+        description: "A test agent",
+        version: "2.1.0",
+        provider: { organization: "LightLayer", url: "https://lightlayer.dev" },
+        documentationUrl: "https://docs.example.com",
+        capabilities: { streaming: true, pushNotifications: false },
+        authentication: { type: "apiKey", in: "header", name: "X-Agent-Key" },
+      },
+    });
+    expect(card.description).toBe("A test agent");
+    expect(card.version).toBe("2.1.0");
+    expect(card.provider?.organization).toBe("LightLayer");
+    expect(card.capabilities?.streaming).toBe(true);
+    expect(card.authentication?.type).toBe("apiKey");
+  });
+
+  it("includes skill tags and examples", () => {
+    const card = generateAgentCard({
+      card: {
+        ...minimalConfig.card,
+        skills: [
+          {
+            id: "translate",
+            name: "Translation",
+            tags: ["nlp", "i18n"],
+            examples: ["Translate hello to French"],
+            inputModes: ["text/plain"],
+            outputModes: ["text/plain"],
+          },
+        ],
+      },
+    });
+    expect(card.skills[0].tags).toEqual(["nlp", "i18n"]);
+    expect(card.skills[0].examples).toEqual(["Translate hello to French"]);
+  });
+});
+
+describe("validateAgentCard", () => {
+  it("returns no errors for a valid card", () => {
+    const errors = validateAgentCard(minimalConfig.card);
+    expect(errors).toEqual([]);
+  });
+
+  it("catches missing name", () => {
+    const errors = validateAgentCard({ ...minimalConfig.card, name: "" as any });
+    expect(errors).toContain("name is required");
+  });
+
+  it("catches missing url", () => {
+    const errors = validateAgentCard({ ...minimalConfig.card, url: "" as any });
+    expect(errors).toContain("url is required");
+  });
+
+  it("catches invalid url scheme", () => {
+    const errors = validateAgentCard({ ...minimalConfig.card, url: "ftp://bad" });
+    expect(errors).toContain("url must be an HTTP(S) URL");
+  });
+
+  it("catches missing skills", () => {
+    const errors = validateAgentCard({ name: "x", url: "https://x.com", protocolVersion: "1.0.0" } as any);
+    expect(errors).toContain("skills is required");
+  });
+
+  it("catches skills without id or name", () => {
+    const errors = validateAgentCard({
+      ...minimalConfig.card,
+      skills: [{ id: "", name: "" } as any],
+    });
+    expect(errors).toContain("each skill must have an id");
+    expect(errors).toContain("each skill must have a name");
+  });
+});

--- a/packages/core/src/a2a.ts
+++ b/packages/core/src/a2a.ts
@@ -1,0 +1,165 @@
+/**
+ * A2A (Agent-to-Agent) Protocol — Agent Card generation.
+ *
+ * Implements the /.well-known/agent.json endpoint per Google's A2A protocol
+ * specification (https://a2a-protocol.org).
+ *
+ * An Agent Card is a JSON metadata document that describes an agent's
+ * capabilities, supported input/output modes, authentication requirements,
+ * and skills — enabling machine-readable discovery by other agents.
+ */
+
+// ── A2A Agent Card Types ────────────────────────────────────────────────
+
+/** Content type supported by the agent (text, images, files, etc.) */
+export interface A2AContentType {
+  /** MIME type, e.g. "text/plain", "application/json", "image/png" */
+  type: string;
+}
+
+/** A skill/capability the agent can perform */
+export interface A2ASkill {
+  /** Unique identifier for the skill */
+  id: string;
+  /** Human-readable name */
+  name: string;
+  /** Description of what this skill does */
+  description?: string;
+  /** Tags for categorization and search */
+  tags?: string[];
+  /** Example prompts/inputs that trigger this skill */
+  examples?: string[];
+  /** Input content types this skill accepts */
+  inputModes?: string[];
+  /** Output content types this skill produces */
+  outputModes?: string[];
+}
+
+/** Authentication scheme the agent supports */
+export interface A2AAuthScheme {
+  /** Auth type: "apiKey", "oauth2", "bearer", "none" */
+  type: string;
+  /** Where to send the credential: "header", "query" */
+  in?: string;
+  /** Header/query parameter name */
+  name?: string;
+  /** OAuth2 authorization URL */
+  authorizationUrl?: string;
+  /** OAuth2 token URL */
+  tokenUrl?: string;
+  /** OAuth2 scopes */
+  scopes?: Record<string, string>;
+}
+
+/** Provider/organization info */
+export interface A2AProvider {
+  /** Organization name */
+  organization: string;
+  /** URL to the provider's website */
+  url?: string;
+}
+
+/** Capabilities the agent supports */
+export interface A2ACapabilities {
+  /** Whether the agent supports streaming responses */
+  streaming?: boolean;
+  /** Whether the agent supports push notifications */
+  pushNotifications?: boolean;
+  /** Whether the agent maintains state across messages */
+  stateTransitionHistory?: boolean;
+}
+
+/** The full Agent Card document served at /.well-known/agent.json */
+export interface A2AAgentCard {
+  /** Agent Card spec version */
+  protocolVersion: string;
+  /** Unique name/identifier for the agent */
+  name: string;
+  /** Human-readable description */
+  description?: string;
+  /** URL where this agent can be reached */
+  url: string;
+  /** Provider/organization */
+  provider?: A2AProvider;
+  /** Version of this agent */
+  version?: string;
+  /** URL to documentation */
+  documentationUrl?: string;
+  /** Agent capabilities */
+  capabilities?: A2ACapabilities;
+  /** Authentication schemes */
+  authentication?: A2AAuthScheme;
+  /** Default input content types */
+  defaultInputModes?: string[];
+  /** Default output content types */
+  defaultOutputModes?: string[];
+  /** Skills/capabilities this agent offers */
+  skills: A2ASkill[];
+}
+
+/** Configuration for generating an Agent Card */
+export interface A2AConfig {
+  /** The Agent Card data */
+  card: A2AAgentCard;
+}
+
+// ── Generator ───────────────────────────────────────────────────────────
+
+/**
+ * Generate a valid A2A Agent Card JSON object.
+ *
+ * Ensures required fields are present and sets sensible defaults.
+ */
+export function generateAgentCard(config: A2AConfig): A2AAgentCard {
+  const card = { ...config.card };
+
+  // Default protocol version to latest stable
+  if (!card.protocolVersion) {
+    card.protocolVersion = "1.0.0";
+  }
+
+  // Default input/output modes to text
+  if (!card.defaultInputModes) {
+    card.defaultInputModes = ["text/plain"];
+  }
+  if (!card.defaultOutputModes) {
+    card.defaultOutputModes = ["text/plain"];
+  }
+
+  // Ensure skills is always an array
+  if (!card.skills) {
+    card.skills = [];
+  }
+
+  return card;
+}
+
+/**
+ * Validate an Agent Card has the minimum required fields.
+ * Returns an array of error messages (empty = valid).
+ */
+export function validateAgentCard(card: Partial<A2AAgentCard>): string[] {
+  const errors: string[] = [];
+
+  if (!card.name) errors.push("name is required");
+  if (!card.url) errors.push("url is required");
+  if (!card.skills) errors.push("skills is required");
+  if (!card.protocolVersion) errors.push("protocolVersion is required");
+
+  if (card.url && !card.url.startsWith("http")) {
+    errors.push("url must be an HTTP(S) URL");
+  }
+
+  if (card.skills && !Array.isArray(card.skills)) {
+    errors.push("skills must be an array");
+  }
+
+  if (card.skills && Array.isArray(card.skills)) {
+    for (const skill of card.skills) {
+      if (!skill.id) errors.push("each skill must have an id");
+      if (!skill.name) errors.push("each skill must have a name");
+    }
+  }
+
+  return errors;
+}

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -1,3 +1,13 @@
+export { generateAgentCard, validateAgentCard } from "./a2a.js";
+export type {
+  A2AAgentCard,
+  A2ASkill,
+  A2AAuthScheme,
+  A2AProvider,
+  A2ACapabilities,
+  A2AContentType,
+  A2AConfig,
+} from "./a2a.js";
 export { formatError, AgentError, notFoundError, rateLimitError } from "./errors.js";
 export { MemoryStore, createRateLimiter } from "./rate-limit.js";
 export { generateLlmsTxt, generateLlmsFullTxt } from "./llms-txt.js";

--- a/packages/core/src/types.ts
+++ b/packages/core/src/types.ts
@@ -165,4 +165,5 @@ export interface AgentLayerConfig {
   agentAuth?: false | AgentAuthConfig;
   analytics?: false | import("./analytics.js").AnalyticsConfig;
   apiKeys?: false | ApiKeyConfig;
+  a2a?: false | import("./a2a.js").A2AConfig;
 }

--- a/packages/express/src/a2a.test.ts
+++ b/packages/express/src/a2a.test.ts
@@ -1,0 +1,91 @@
+import { describe, it, expect } from "vitest";
+import express from "express";
+import request from "supertest";
+import { a2aRoutes } from "./a2a.js";
+import type { A2AConfig } from "@agent-layer/core";
+
+const testConfig: A2AConfig = {
+  card: {
+    protocolVersion: "1.0.0",
+    name: "test-agent",
+    description: "A test agent for unit tests",
+    url: "https://example.com/agent",
+    provider: { organization: "LightLayer", url: "https://lightlayer.dev" },
+    version: "1.0.0",
+    capabilities: { streaming: false, pushNotifications: false },
+    authentication: { type: "apiKey", in: "header", name: "X-Agent-Key" },
+    skills: [
+      {
+        id: "search",
+        name: "Web Search",
+        description: "Search the web for information",
+        tags: ["search", "web"],
+        examples: ["Search for AI agent protocols"],
+      },
+      {
+        id: "summarize",
+        name: "Summarize",
+        description: "Summarize a document or URL",
+        tags: ["nlp", "summarization"],
+      },
+    ],
+  },
+};
+
+function createApp(config: A2AConfig) {
+  const app = express();
+  const handlers = a2aRoutes(config);
+  app.get("/.well-known/agent.json", handlers.agentCard);
+  return app;
+}
+
+describe("a2aRoutes", () => {
+  it("serves agent card at /.well-known/agent.json", async () => {
+    const app = createApp(testConfig);
+    const res = await request(app).get("/.well-known/agent.json");
+    expect(res.status).toBe(200);
+    expect(res.body.name).toBe("test-agent");
+    expect(res.body.url).toBe("https://example.com/agent");
+    expect(res.body.protocolVersion).toBe("1.0.0");
+  });
+
+  it("includes all skills", async () => {
+    const app = createApp(testConfig);
+    const res = await request(app).get("/.well-known/agent.json");
+    expect(res.body.skills).toHaveLength(2);
+    expect(res.body.skills[0].id).toBe("search");
+    expect(res.body.skills[1].id).toBe("summarize");
+  });
+
+  it("includes provider info", async () => {
+    const app = createApp(testConfig);
+    const res = await request(app).get("/.well-known/agent.json");
+    expect(res.body.provider.organization).toBe("LightLayer");
+  });
+
+  it("includes capabilities", async () => {
+    const app = createApp(testConfig);
+    const res = await request(app).get("/.well-known/agent.json");
+    expect(res.body.capabilities.streaming).toBe(false);
+  });
+
+  it("includes authentication scheme", async () => {
+    const app = createApp(testConfig);
+    const res = await request(app).get("/.well-known/agent.json");
+    expect(res.body.authentication.type).toBe("apiKey");
+    expect(res.body.authentication.in).toBe("header");
+  });
+
+  it("sets cache-control header", async () => {
+    const app = createApp(testConfig);
+    const res = await request(app).get("/.well-known/agent.json");
+    expect(res.headers["cache-control"]).toBe("public, max-age=3600");
+  });
+
+  it("sets default input/output modes", async () => {
+    const app = createApp(testConfig);
+    const res = await request(app).get("/.well-known/agent.json");
+    expect(res.body.defaultInputModes).toEqual(["text/plain"]);
+    expect(res.body.defaultOutputModes).toEqual(["text/plain"]);
+  });
+});

--- a/packages/express/src/a2a.ts
+++ b/packages/express/src/a2a.ts
@@ -1,0 +1,24 @@
+import type { Request, Response } from "express";
+import { generateAgentCard } from "@agent-layer/core";
+import type { A2AConfig } from "@agent-layer/core";
+
+/**
+ * Create Express route handlers for the A2A Agent Card endpoint.
+ *
+ * Serves the agent card at /.well-known/agent.json per the A2A protocol spec.
+ */
+export function a2aRoutes(config: A2AConfig) {
+  const card = generateAgentCard(config);
+
+  return {
+    /**
+     * GET /.well-known/agent.json handler.
+     *
+     * Returns the A2A Agent Card JSON document for agent discovery.
+     */
+    agentCard(_req: Request, res: Response): void {
+      res.setHeader("Cache-Control", "public, max-age=3600");
+      res.json(card);
+    },
+  };
+}

--- a/packages/express/src/index.ts
+++ b/packages/express/src/index.ts
@@ -9,6 +9,7 @@ import { agentMeta } from "./agent-meta.js";
 import { agentAuth } from "./agent-auth.js";
 import { agentAnalytics } from "./analytics.js";
 import { apiKeyAuth } from "./api-keys.js";
+import { a2aRoutes } from "./a2a.js";
 
 export { agentErrors, notFoundHandler } from "./agent-errors.js";
 export { rateLimits } from "./rate-limits.js";
@@ -19,6 +20,7 @@ export { agentAuth } from "./agent-auth.js";
 export { agentAnalytics } from "./analytics.js";
 export type { AnalyticsConfig, AnalyticsInstance, AgentEvent } from "./analytics.js";
 export { apiKeyAuth, requireScope } from "./api-keys.js";
+export { a2aRoutes } from "./a2a.js";
 
 /**
  * One-liner that composes all agent-layer middleware onto a single Express router.
@@ -59,6 +61,12 @@ export function agentLayer(config: AgentLayerConfig): Router {
     const handlers = discoveryRoutes(config.discovery);
     router.get("/.well-known/ai", handlers.wellKnownAi);
     router.get("/openapi.json", handlers.openApiJson);
+  }
+
+  // A2A Agent Card (/.well-known/agent.json)
+  if (config.a2a !== false && config.a2a) {
+    const handlers = a2aRoutes(config.a2a);
+    router.get("/.well-known/agent.json", handlers.agentCard);
   }
 
   // Auth discovery

--- a/packages/koa/src/a2a.test.ts
+++ b/packages/koa/src/a2a.test.ts
@@ -1,0 +1,50 @@
+import { describe, it, expect } from "vitest";
+import Koa from "koa";
+import Router from "@koa/router";
+import request from "supertest";
+import { a2aRoutes } from "./a2a.js";
+import type { A2AConfig } from "@agent-layer/core";
+
+const testConfig: A2AConfig = {
+  card: {
+    protocolVersion: "1.0.0",
+    name: "test-agent",
+    url: "https://example.com/agent",
+    skills: [
+      { id: "search", name: "Web Search" },
+    ],
+  },
+};
+
+function createApp(config: A2AConfig) {
+  const app = new Koa();
+  const router = new Router();
+  const handlers = a2aRoutes(config);
+  router.get("/.well-known/agent.json", handlers.agentCard);
+  app.use(router.routes());
+  return app.callback();
+}
+
+describe("a2aRoutes (Koa)", () => {
+  it("serves agent card at /.well-known/agent.json", async () => {
+    const app = createApp(testConfig);
+    const res = await request(app).get("/.well-known/agent.json");
+    expect(res.status).toBe(200);
+    expect(res.body.name).toBe("test-agent");
+    expect(res.body.protocolVersion).toBe("1.0.0");
+    expect(res.body.skills).toHaveLength(1);
+  });
+
+  it("sets cache-control header", async () => {
+    const app = createApp(testConfig);
+    const res = await request(app).get("/.well-known/agent.json");
+    expect(res.headers["cache-control"]).toBe("public, max-age=3600");
+  });
+
+  it("includes default input/output modes", async () => {
+    const app = createApp(testConfig);
+    const res = await request(app).get("/.well-known/agent.json");
+    expect(res.body.defaultInputModes).toEqual(["text/plain"]);
+    expect(res.body.defaultOutputModes).toEqual(["text/plain"]);
+  });
+});

--- a/packages/koa/src/a2a.ts
+++ b/packages/koa/src/a2a.ts
@@ -1,0 +1,20 @@
+import type { Context } from "koa";
+import { generateAgentCard } from "@agent-layer/core";
+import type { A2AConfig } from "@agent-layer/core";
+
+/**
+ * Create Koa route handlers for the A2A Agent Card endpoint.
+ */
+export function a2aRoutes(config: A2AConfig) {
+  const card = generateAgentCard(config);
+
+  return {
+    /**
+     * GET /.well-known/agent.json handler.
+     */
+    agentCard(ctx: Context): void {
+      ctx.set("Cache-Control", "public, max-age=3600");
+      ctx.body = card;
+    },
+  };
+}

--- a/packages/koa/src/index.ts
+++ b/packages/koa/src/index.ts
@@ -7,6 +7,7 @@ import { discoveryRoutes } from "./discovery.js";
 import { agentMeta } from "./agent-meta.js";
 import { agentAuth } from "./agent-auth.js";
 import { apiKeyAuth } from "./api-keys.js";
+import { a2aRoutes } from "./a2a.js";
 
 export { agentErrors, notFoundHandler } from "./agent-errors.js";
 export { rateLimits } from "./rate-limits.js";
@@ -15,6 +16,7 @@ export { discoveryRoutes } from "./discovery.js";
 export { agentMeta } from "./agent-meta.js";
 export { agentAuth } from "./agent-auth.js";
 export { apiKeyAuth, requireScope } from "./api-keys.js";
+export { a2aRoutes } from "./a2a.js";
 
 /**
  * One-liner that composes all agent-layer middleware onto a single Koa Router.
@@ -50,6 +52,12 @@ export function agentLayer(config: AgentLayerConfig): Router {
     const handlers = discoveryRoutes(config.discovery);
     router.get("/.well-known/ai", handlers.wellKnownAi);
     router.get("/openapi.json", handlers.openApiJson);
+  }
+
+  // A2A Agent Card (/.well-known/agent.json)
+  if (config.a2a !== false && config.a2a) {
+    const handlers = a2aRoutes(config.a2a);
+    router.get("/.well-known/agent.json", handlers.agentCard);
   }
 
   // Auth discovery


### PR DESCRIPTION
## What

Implements the A2A (Agent-to-Agent) protocol's Agent Card endpoint, serving machine-readable capability metadata at `/.well-known/agent.json`.

Per the [A2A protocol spec](https://a2a-protocol.org) (Google's open standard for agent interoperability), any A2A-compatible agent must publish an Agent Card — a JSON document describing its skills, capabilities, authentication requirements, and supported input/output modes.

## Why

**Strategic: middleware adoption moat.** A2A is becoming the standard for agent-to-agent discovery. By making agent-layer the easiest way to serve an Agent Card, every app using our middleware becomes discoverable by other agents — deepening the network effect.

This complements our existing discovery features (`/.well-known/ai`, `/llms.txt`, JSON-LD) and positions agent-layer as the one-stop middleware for making any API agent-friendly.

## Changes

### Core (`@agent-layer/core`)
- `A2AAgentCard` type with full spec coverage (skills, capabilities, authentication, provider, input/output modes)
- `generateAgentCard()` with sensible defaults
- `validateAgentCard()` for runtime validation
- 12 unit tests

### Express (`@agent-layer/express`)
- `a2aRoutes()` handler at `/.well-known/agent.json` with Cache-Control
- Wired into `agentLayer()` one-liner via `config.a2a`
- 7 integration tests

### Koa (`@agent-layer/koa`)
- `a2aRoutes()` matching Express behavior
- Wired into `agentLayer()` one-liner
- 3 integration tests

## Usage

```ts
import { agentLayer } from '@agent-layer/express';

app.use(agentLayer({
  a2a: {
    card: {
      name: 'my-agent',
      url: 'https://api.example.com',
      skills: [
        { id: 'search', name: 'Search', description: 'Search products' }
      ],
      capabilities: { streaming: true },
      authentication: { type: 'apiKey', in: 'header', name: 'X-API-Key' },
    }
  }
}));
// GET /.well-known/agent.json → Agent Card JSON
```

**297 tests passing (31 test files)**