### PR TITLE
audit: 2026-03-30 — framework onboarding adapters + TS fixes

### DIFF
--- a/packages/express/src/agent-onboarding.test.ts
+++ b/packages/express/src/agent-onboarding.test.ts
@@ -1,0 +1,181 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import express from "express";
+import request from "supertest";
+import { agentOnboarding } from "./agent-onboarding.js";
+import type { OnboardingConfig } from "@agent-layer/core";
+
+// Mock fetch for webhook calls.
+const mockFetch = vi.fn();
+vi.stubGlobal("fetch", mockFetch);
+
+const baseConfig: OnboardingConfig = {
+  provisioningWebhook: "https://hooks.example.com/provision",
+};
+
+function createApp(config: OnboardingConfig = baseConfig) {
+  const app = express();
+  app.use(express.json());
+  const onboarding = agentOnboarding(config);
+  app.use(onboarding.registerRoute());
+  app.use(onboarding.authRequired());
+  app.get("/api/data", (_req, res) => res.json({ ok: true }));
+  app.get("/llms.txt", (_req, res) => res.send("# LLMs.txt"));
+  app.get("/.well-known/agent.json", (_req, res) => res.json({ name: "test" }));
+  return app;
+}
+
+const validBody = {
+  agent_id: "agent-123",
+  agent_name: "TestBot",
+  agent_provider: "openai",
+};
+
+describe("agentOnboarding middleware (Express)", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("registers agent successfully", async () => {
+    mockFetch.mockResolvedValueOnce({
+      ok: true,
+      json: async () => ({
+        status: "provisioned",
+        credentials: { type: "api_key", token: "sk-test-123", header: "X-API-Key" },
+      }),
+    });
+
+    const app = createApp();
+    const res = await request(app).post("/agent/register").send(validBody);
+
+    expect(res.status).toBe(200);
+    expect(res.body.status).toBe("provisioned");
+    expect(res.body.credentials.token).toBe("sk-test-123");
+  });
+
+  it("returns 400 for missing agent_id", async () => {
+    const app = createApp();
+    const res = await request(app)
+      .post("/agent/register")
+      .send({ agent_name: "Bot", agent_provider: "openai" });
+
+    expect(res.status).toBe(400);
+    expect(res.body.code).toBe("missing_field");
+  });
+
+  it("returns 400 for missing agent_name", async () => {
+    const app = createApp();
+    const res = await request(app)
+      .post("/agent/register")
+      .send({ agent_id: "a1", agent_provider: "openai" });
+
+    expect(res.status).toBe(400);
+    expect(res.body.code).toBe("missing_field");
+  });
+
+  it("returns 400 for missing agent_provider", async () => {
+    const app = createApp();
+    const res = await request(app)
+      .post("/agent/register")
+      .send({ agent_id: "a1", agent_name: "Bot" });
+
+    expect(res.status).toBe(400);
+    expect(res.body.code).toBe("missing_field");
+  });
+
+  it("returns 429 when rate limited", async () => {
+    mockFetch.mockResolvedValue({
+      ok: true,
+      json: async () => ({ status: "provisioned", credentials: { type: "api_key", token: "t" } }),
+    });
+
+    const config: OnboardingConfig = {
+      ...baseConfig,
+      rateLimit: { maxRegistrations: 2, windowMs: 60_000 },
+    };
+    const app = createApp(config);
+
+    await request(app).post("/agent/register").send(validBody);
+    await request(app).post("/agent/register").send(validBody);
+    const res = await request(app).post("/agent/register").send(validBody);
+
+    expect(res.status).toBe(429);
+    expect(res.body.code).toBe("rate_limit_exceeded");
+  });
+
+  it("returns 401 for unauthenticated request on non-exempt path", async () => {
+    const app = createApp();
+    const res = await request(app).get("/api/data");
+
+    expect(res.status).toBe(401);
+    expect(res.body.error).toBe("auth_required");
+    expect(res.body.register_url).toBe("/agent/register");
+  });
+
+  it("passes through requests with Authorization header", async () => {
+    const app = createApp();
+    const res = await request(app)
+      .get("/api/data")
+      .set("Authorization", "Bearer sk-test");
+
+    expect(res.status).toBe(200);
+    expect(res.body.ok).toBe(true);
+  });
+
+  it("passes through requests with X-API-Key header", async () => {
+    const app = createApp();
+    const res = await request(app)
+      .get("/api/data")
+      .set("X-API-Key", "key-123");
+
+    expect(res.status).toBe(200);
+    expect(res.body.ok).toBe(true);
+  });
+
+  it("does not block /llms.txt (exempt path)", async () => {
+    const app = createApp();
+    const res = await request(app).get("/llms.txt");
+
+    expect(res.status).toBe(200);
+  });
+
+  it("does not block /.well-known/ paths", async () => {
+    const app = createApp();
+    const res = await request(app).get("/.well-known/agent.json");
+
+    expect(res.status).toBe(200);
+  });
+
+  it("returns 403 for disallowed provider", async () => {
+    const config: OnboardingConfig = {
+      ...baseConfig,
+      allowedProviders: ["anthropic"],
+    };
+    const app = createApp(config);
+    const res = await request(app).post("/agent/register").send(validBody);
+
+    expect(res.status).toBe(403);
+    expect(res.body.code).toBe("provider_not_allowed");
+  });
+
+  it("returns 502 when webhook fails", async () => {
+    mockFetch.mockRejectedValueOnce(new Error("Connection refused"));
+
+    const app = createApp();
+    const res = await request(app).post("/agent/register").send(validBody);
+
+    expect(res.status).toBe(502);
+    expect(res.body.code).toBe("webhook_error");
+  });
+
+  it("includes auth_docs in 401 response when configured", async () => {
+    const config: OnboardingConfig = {
+      ...baseConfig,
+      authDocs: "https://docs.example.com/auth",
+    };
+    const app = createApp(config);
+    const res = await request(app).get("/api/data");
+
+    expect(res.status).toBe(401);
+    expect(res.body.auth_docs).toBe("https://docs.example.com/auth");
+  });
+});

--- a/packages/express/src/agent-onboarding.ts
+++ b/packages/express/src/agent-onboarding.ts
@@ -1,0 +1,62 @@
+import type { Request, Response, NextFunction, Router } from "express";
+import { Router as createRouter } from "express";
+import type {
+  OnboardingConfig,
+  RegistrationRequest,
+} from "@agent-layer/core";
+import { createOnboardingHandler } from "@agent-layer/core";
+
+/**
+ * Express adapter for agent-onboarding.
+ *
+ * Returns a router with POST /agent/register and an authRequired() middleware
+ * that returns 401 for unauthenticated agent requests on non-exempt paths.
+ */
+export function agentOnboarding(config: OnboardingConfig) {
+  const handler = createOnboardingHandler(config);
+
+  function getClientIp(req: Request): string {
+    const forwarded = req.headers["x-forwarded-for"];
+    if (forwarded) {
+      const first = Array.isArray(forwarded) ? forwarded[0] : forwarded.split(",")[0];
+      return first.trim();
+    }
+    return req.socket?.remoteAddress ?? "unknown";
+  }
+
+  /** Returns an Express Router that mounts POST /agent/register. */
+  function registerRoute(): Router {
+    const router = createRouter();
+
+    router.post("/agent/register", async (req: Request, res: Response): Promise<void> => {
+      const body = req.body as RegistrationRequest;
+      const ip = getClientIp(req);
+      const result = await handler.handleRegister(body, ip);
+      res.status(result.status).json(result.body);
+    });
+
+    return router;
+  }
+
+  /** Middleware that returns 401 for unauthenticated requests on non-exempt paths. */
+  function authRequired() {
+    return function authRequiredMiddleware(
+      req: Request,
+      res: Response,
+      next: NextFunction,
+    ): void {
+      const headers: Record<string, string | undefined> = {};
+      for (const [k, v] of Object.entries(req.headers)) {
+        headers[k] = Array.isArray(v) ? v[0] : v;
+      }
+
+      if (handler.shouldReturn401(req.path, headers)) {
+        res.status(401).json(handler.getAuthRequiredResponse());
+        return;
+      }
+      next();
+    };
+  }
+
+  return { registerRoute, authRequired };
+}

--- a/packages/express/src/index.ts
+++ b/packages/express/src/index.ts
@@ -20,6 +20,7 @@ export { llmsTxtRoutes } from "./llms-txt.js";
 export { discoveryRoutes } from "./discovery.js";
 export { agentMeta } from "./agent-meta.js";
 export { agentAuth } from "./agent-auth.js";
+export { agentOnboarding } from "./agent-onboarding.js";
 export { agentAnalytics } from "./analytics.js";
 export type { AnalyticsConfig, AnalyticsInstance, AgentEvent } from "./analytics.js";
 export { apiKeyAuth, requireScope } from "./api-keys.js";

--- a/packages/fastify/src/agent-onboarding.test.ts
+++ b/packages/fastify/src/agent-onboarding.test.ts
@@ -1,0 +1,142 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import Fastify from "fastify";
+import { agentOnboarding } from "./agent-onboarding.js";
+import type { OnboardingConfig } from "@agent-layer/core";
+
+const mockFetch = vi.fn();
+vi.stubGlobal("fetch", mockFetch);
+
+const baseConfig: OnboardingConfig = {
+  provisioningWebhook: "https://hooks.example.com/provision",
+};
+
+const validBody = {
+  agent_id: "agent-123",
+  agent_name: "TestBot",
+  agent_provider: "openai",
+};
+
+function createApp(config: OnboardingConfig = baseConfig) {
+  const app = Fastify();
+  const onboarding = agentOnboarding(config);
+  app.register(onboarding.registerPlugin);
+  app.addHook("onRequest", onboarding.authRequired());
+  app.get("/api/data", async () => ({ ok: true }));
+  app.get("/llms.txt", async (_req, reply) => {
+    reply.type("text/plain").send("# LLMs.txt");
+  });
+  app.get("/.well-known/agent.json", async () => ({ name: "test" }));
+  return app;
+}
+
+describe("agentOnboarding (Fastify)", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("registers agent successfully", async () => {
+    mockFetch.mockResolvedValueOnce({
+      ok: true,
+      json: async () => ({
+        status: "provisioned",
+        credentials: { type: "api_key", token: "sk-test-123" },
+      }),
+    });
+
+    const app = createApp();
+    const res = await app.inject({
+      method: "POST",
+      url: "/agent/register",
+      payload: validBody,
+    });
+
+    expect(res.statusCode).toBe(200);
+    const body = res.json();
+    expect(body.status).toBe("provisioned");
+  });
+
+  it("returns 400 for missing agent_id", async () => {
+    const app = createApp();
+    const res = await app.inject({
+      method: "POST",
+      url: "/agent/register",
+      payload: { agent_name: "Bot", agent_provider: "openai" },
+    });
+    expect(res.statusCode).toBe(400);
+    expect(res.json().code).toBe("missing_field");
+  });
+
+  it("returns 429 when rate limited", async () => {
+    mockFetch.mockResolvedValue({
+      ok: true,
+      json: async () => ({ status: "provisioned", credentials: { type: "api_key", token: "t" } }),
+    });
+
+    const config: OnboardingConfig = {
+      ...baseConfig,
+      rateLimit: { maxRegistrations: 2, windowMs: 60_000 },
+    };
+    const app = createApp(config);
+
+    await app.inject({ method: "POST", url: "/agent/register", payload: validBody });
+    await app.inject({ method: "POST", url: "/agent/register", payload: validBody });
+    const res = await app.inject({ method: "POST", url: "/agent/register", payload: validBody });
+
+    expect(res.statusCode).toBe(429);
+  });
+
+  it("returns 401 for unauthenticated request", async () => {
+    const app = createApp();
+    const res = await app.inject({ method: "GET", url: "/api/data" });
+
+    expect(res.statusCode).toBe(401);
+    expect(res.json().error).toBe("auth_required");
+  });
+
+  it("passes through with Authorization header", async () => {
+    const app = createApp();
+    const res = await app.inject({
+      method: "GET",
+      url: "/api/data",
+      headers: { authorization: "Bearer sk-test" },
+    });
+    expect(res.statusCode).toBe(200);
+  });
+
+  it("does not block /llms.txt", async () => {
+    const app = createApp();
+    const res = await app.inject({ method: "GET", url: "/llms.txt" });
+    expect(res.statusCode).toBe(200);
+  });
+
+  it("does not block /.well-known/ paths", async () => {
+    const app = createApp();
+    const res = await app.inject({ method: "GET", url: "/.well-known/agent.json" });
+    expect(res.statusCode).toBe(200);
+  });
+
+  it("returns 403 for disallowed provider", async () => {
+    const config: OnboardingConfig = {
+      ...baseConfig,
+      allowedProviders: ["anthropic"],
+    };
+    const app = createApp(config);
+    const res = await app.inject({
+      method: "POST",
+      url: "/agent/register",
+      payload: validBody,
+    });
+    expect(res.statusCode).toBe(403);
+  });
+
+  it("returns 502 when webhook fails", async () => {
+    mockFetch.mockRejectedValueOnce(new Error("Connection refused"));
+    const app = createApp();
+    const res = await app.inject({
+      method: "POST",
+      url: "/agent/register",
+      payload: validBody,
+    });
+    expect(res.statusCode).toBe(502);
+  });
+});

--- a/packages/fastify/src/agent-onboarding.ts
+++ b/packages/fastify/src/agent-onboarding.ts
@@ -1,0 +1,58 @@
+import type { FastifyInstance, FastifyRequest, FastifyReply } from "fastify";
+import fp from "fastify-plugin";
+import type {
+  OnboardingConfig,
+  RegistrationRequest,
+} from "@agent-layer/core";
+import { createOnboardingHandler } from "@agent-layer/core";
+
+/**
+ * Fastify adapter for agent-onboarding.
+ *
+ * Returns a Fastify plugin that mounts POST /agent/register and an
+ * authRequired hook returning 401 for unauthenticated agent requests.
+ */
+export function agentOnboarding(config: OnboardingConfig) {
+  const handler = createOnboardingHandler(config);
+
+  function getClientIp(request: FastifyRequest): string {
+    const forwarded = request.headers["x-forwarded-for"];
+    if (forwarded) {
+      const first = Array.isArray(forwarded) ? forwarded[0] : forwarded.split(",")[0];
+      return first.trim();
+    }
+    return request.ip ?? "unknown";
+  }
+
+  /** Fastify plugin that registers POST /agent/register. */
+  const registerPlugin = fp(
+    async function agentOnboardingRegisterPlugin(fastify: FastifyInstance) {
+      fastify.post("/agent/register", async (request: FastifyRequest, reply: FastifyReply) => {
+        const body = request.body as RegistrationRequest;
+        const ip = getClientIp(request);
+        const result = await handler.handleRegister(body, ip);
+        reply.status(result.status).send(result.body);
+      });
+    },
+    { name: "agent-layer-onboarding-register" },
+  );
+
+  /** Hook that returns 401 for unauthenticated requests on non-exempt paths. */
+  function authRequired() {
+    return async function authRequiredHook(
+      request: FastifyRequest,
+      reply: FastifyReply,
+    ): Promise<void> {
+      const headers: Record<string, string | undefined> = {};
+      for (const [k, v] of Object.entries(request.headers)) {
+        headers[k] = Array.isArray(v) ? v[0] : v;
+      }
+
+      if (handler.shouldReturn401(request.url, headers)) {
+        reply.status(401).send(handler.getAuthRequiredResponse());
+      }
+    };
+  }
+
+  return { registerPlugin, authRequired };
+}

--- a/packages/fastify/src/index.ts
+++ b/packages/fastify/src/index.ts
@@ -20,6 +20,7 @@ export { llmsTxtRoutes } from "./llms-txt.js";
 export { discoveryRoutes } from "./discovery.js";
 export { agentMeta } from "./agent-meta.js";
 export { agentAuth } from "./agent-auth.js";
+export { agentOnboarding } from "./agent-onboarding.js";
 export { agentAnalytics } from "./analytics.js";
 export type { AnalyticsConfig, AnalyticsInstance, AgentEvent } from "./analytics.js";
 export { apiKeyAuth, requireScope } from "./api-keys.js";

--- a/packages/hono/src/agent-onboarding.test.ts
+++ b/packages/hono/src/agent-onboarding.test.ts
@@ -1,0 +1,136 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { Hono } from "hono";
+import { agentOnboarding } from "./agent-onboarding.js";
+import type { OnboardingConfig } from "@agent-layer/core";
+
+const mockFetch = vi.fn();
+vi.stubGlobal("fetch", mockFetch);
+
+const baseConfig: OnboardingConfig = {
+  provisioningWebhook: "https://hooks.example.com/provision",
+};
+
+function createApp(config: OnboardingConfig = baseConfig) {
+  const app = new Hono();
+  const onboarding = agentOnboarding(config);
+  app.route("/", onboarding.registerRoute());
+  app.use("/*", onboarding.authRequired());
+  app.get("/api/data", (c) => c.json({ ok: true }));
+  app.get("/llms.txt", (c) => c.text("# LLMs.txt"));
+  app.get("/.well-known/agent.json", (c) => c.json({ name: "test" }));
+  return app;
+}
+
+const validBody = {
+  agent_id: "agent-123",
+  agent_name: "TestBot",
+  agent_provider: "openai",
+};
+
+async function req(app: Hono, method: string, path: string, body?: unknown, headers?: Record<string, string>) {
+  const init: RequestInit = { method, headers: { ...headers } };
+  if (body) {
+    init.body = JSON.stringify(body);
+    (init.headers as Record<string, string>)["content-type"] = "application/json";
+  }
+  return app.request(path, init);
+}
+
+describe("agentOnboarding middleware (Hono)", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("registers agent successfully", async () => {
+    mockFetch.mockResolvedValueOnce({
+      ok: true,
+      json: async () => ({
+        status: "provisioned",
+        credentials: { type: "api_key", token: "sk-test-123" },
+      }),
+    });
+
+    const app = createApp();
+    const res = await req(app, "POST", "/agent/register", validBody);
+
+    expect(res.status).toBe(200);
+    const json = await res.json();
+    expect(json.status).toBe("provisioned");
+  });
+
+  it("returns 400 for missing agent_id", async () => {
+    const app = createApp();
+    const res = await req(app, "POST", "/agent/register", {
+      agent_name: "Bot",
+      agent_provider: "openai",
+    });
+    expect(res.status).toBe(400);
+    const json = await res.json();
+    expect(json.code).toBe("missing_field");
+  });
+
+  it("returns 429 when rate limited", async () => {
+    mockFetch.mockResolvedValue({
+      ok: true,
+      json: async () => ({ status: "provisioned", credentials: { type: "api_key", token: "t" } }),
+    });
+
+    const config: OnboardingConfig = {
+      ...baseConfig,
+      rateLimit: { maxRegistrations: 2, windowMs: 60_000 },
+    };
+    const app = createApp(config);
+
+    await req(app, "POST", "/agent/register", validBody);
+    await req(app, "POST", "/agent/register", validBody);
+    const res = await req(app, "POST", "/agent/register", validBody);
+
+    expect(res.status).toBe(429);
+  });
+
+  it("returns 401 for unauthenticated request", async () => {
+    const app = createApp();
+    const res = await req(app, "GET", "/api/data");
+
+    expect(res.status).toBe(401);
+    const json = await res.json();
+    expect(json.error).toBe("auth_required");
+  });
+
+  it("passes through with Authorization header", async () => {
+    const app = createApp();
+    const res = await req(app, "GET", "/api/data", undefined, {
+      authorization: "Bearer sk-test",
+    });
+    expect(res.status).toBe(200);
+  });
+
+  it("does not block /llms.txt", async () => {
+    const app = createApp();
+    const res = await req(app, "GET", "/llms.txt");
+    expect(res.status).toBe(200);
+  });
+
+  it("does not block /.well-known/ paths", async () => {
+    const app = createApp();
+    const res = await req(app, "GET", "/.well-known/agent.json");
+    expect(res.status).toBe(200);
+  });
+
+  it("returns 403 for disallowed provider", async () => {
+    const config: OnboardingConfig = {
+      ...baseConfig,
+      allowedProviders: ["anthropic"],
+    };
+    const app = createApp(config);
+    const res = await req(app, "POST", "/agent/register", validBody);
+    expect(res.status).toBe(403);
+  });
+
+  it("returns 502 when webhook fails", async () => {
+    mockFetch.mockRejectedValueOnce(new Error("Connection refused"));
+    const app = createApp();
+    const res = await req(app, "POST", "/agent/register", validBody);
+    expect(res.status).toBe(502);
+  });
+});

--- a/packages/hono/src/agent-onboarding.ts
+++ b/packages/hono/src/agent-onboarding.ts
@@ -1,0 +1,57 @@
+import { Hono } from "hono";
+import type { Context, Next } from "hono";
+import type {
+  OnboardingConfig,
+  RegistrationRequest,
+} from "@agent-layer/core";
+import { createOnboardingHandler } from "@agent-layer/core";
+
+/**
+ * Hono adapter for agent-onboarding.
+ *
+ * Returns a Hono app with POST /agent/register and an authRequired() middleware
+ * that returns 401 for unauthenticated agent requests on non-exempt paths.
+ */
+export function agentOnboarding(config: OnboardingConfig) {
+  const handler = createOnboardingHandler(config);
+
+  function getClientIp(c: Context): string {
+    const forwarded = c.req.header("x-forwarded-for");
+    if (forwarded) return forwarded.split(",")[0].trim();
+    return "unknown";
+  }
+
+  /** Returns a Hono app with POST /agent/register. */
+  function registerRoute(): Hono {
+    const app = new Hono();
+
+    app.post("/agent/register", async (c) => {
+      const body = (await c.req.json()) as RegistrationRequest;
+      const ip = getClientIp(c);
+      const result = await handler.handleRegister(body, ip);
+      return c.json(result.body, result.status as any);
+    });
+
+    return app;
+  }
+
+  /** Middleware that returns 401 for unauthenticated requests on non-exempt paths. */
+  function authRequired() {
+    return async function authRequiredMiddleware(
+      c: Context,
+      next: Next,
+    ): Promise<Response | void> {
+      const headers: Record<string, string | undefined> = {};
+      c.req.raw.headers.forEach((value, key) => {
+        headers[key] = value;
+      });
+
+      if (handler.shouldReturn401(c.req.path, headers)) {
+        return c.json(handler.getAuthRequiredResponse(), 401);
+      }
+      await next();
+    };
+  }
+
+  return { registerRoute, authRequired };
+}

--- a/packages/hono/src/index.ts
+++ b/packages/hono/src/index.ts
@@ -19,6 +19,7 @@ export { llmsTxtRoutes } from "./llms-txt.js";
 export { discoveryRoutes } from "./discovery.js";
 export { agentMeta } from "./agent-meta.js";
 export { agentAuth } from "./agent-auth.js";
+export { agentOnboarding } from "./agent-onboarding.js";
 export { agentAnalytics } from "./analytics.js";
 export type { AnalyticsConfig, AnalyticsInstance, AgentEvent } from "./analytics.js";
 export { apiKeyAuth, requireScope } from "./api-keys.js";

--- a/packages/koa/src/agent-onboarding.test.ts
+++ b/packages/koa/src/agent-onboarding.test.ts
@@ -1,0 +1,150 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import Koa from "koa";
+import Router from "@koa/router";
+import bodyParser from "koa-bodyparser";
+import request from "supertest";
+import { agentOnboarding } from "./agent-onboarding.js";
+import type { OnboardingConfig } from "@agent-layer/core";
+
+const mockFetch = vi.fn();
+vi.stubGlobal("fetch", mockFetch);
+
+const baseConfig: OnboardingConfig = {
+  provisioningWebhook: "https://hooks.example.com/provision",
+};
+
+const validBody = {
+  agent_id: "agent-123",
+  agent_name: "TestBot",
+  agent_provider: "openai",
+};
+
+function createApp(config: OnboardingConfig = baseConfig) {
+  const app = new Koa();
+  app.use(bodyParser());
+  const onboarding = agentOnboarding(config);
+
+  const registerRouter = onboarding.registerRoute();
+  app.use(registerRouter.routes());
+  app.use(registerRouter.allowedMethods());
+
+  app.use(onboarding.authRequired());
+
+  const routes = new Router();
+  routes.get("/api/data", (ctx) => {
+    ctx.body = { ok: true };
+  });
+  routes.get("/llms.txt", (ctx) => {
+    ctx.body = "# LLMs.txt";
+  });
+  routes.get("/.well-known/agent.json", (ctx) => {
+    ctx.body = { name: "test" };
+  });
+  app.use(routes.routes());
+  app.use(routes.allowedMethods());
+
+  return app;
+}
+
+describe("agentOnboarding middleware (Koa)", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("registers agent successfully", async () => {
+    mockFetch.mockResolvedValueOnce({
+      ok: true,
+      json: async () => ({
+        status: "provisioned",
+        credentials: { type: "api_key", token: "sk-test-123" },
+      }),
+    });
+
+    const app = createApp();
+    const res = await request(app.callback())
+      .post("/agent/register")
+      .send(validBody);
+
+    expect(res.status).toBe(200);
+    expect(res.body.status).toBe("provisioned");
+  });
+
+  it("returns 400 for missing agent_id", async () => {
+    const app = createApp();
+    const res = await request(app.callback())
+      .post("/agent/register")
+      .send({ agent_name: "Bot", agent_provider: "openai" });
+
+    expect(res.status).toBe(400);
+    expect(res.body.code).toBe("missing_field");
+  });
+
+  it("returns 429 when rate limited", async () => {
+    mockFetch.mockResolvedValue({
+      ok: true,
+      json: async () => ({ status: "provisioned", credentials: { type: "api_key", token: "t" } }),
+    });
+
+    const config: OnboardingConfig = {
+      ...baseConfig,
+      rateLimit: { maxRegistrations: 2, windowMs: 60_000 },
+    };
+    const app = createApp(config);
+    const cb = app.callback();
+
+    await request(cb).post("/agent/register").send(validBody);
+    await request(cb).post("/agent/register").send(validBody);
+    const res = await request(cb).post("/agent/register").send(validBody);
+
+    expect(res.status).toBe(429);
+  });
+
+  it("returns 401 for unauthenticated request", async () => {
+    const app = createApp();
+    const res = await request(app.callback()).get("/api/data");
+
+    expect(res.status).toBe(401);
+    expect(res.body.error).toBe("auth_required");
+  });
+
+  it("passes through with Authorization header", async () => {
+    const app = createApp();
+    const res = await request(app.callback())
+      .get("/api/data")
+      .set("Authorization", "Bearer sk-test");
+    expect(res.status).toBe(200);
+  });
+
+  it("does not block /llms.txt", async () => {
+    const app = createApp();
+    const res = await request(app.callback()).get("/llms.txt");
+    expect(res.status).toBe(200);
+  });
+
+  it("does not block /.well-known/ paths", async () => {
+    const app = createApp();
+    const res = await request(app.callback()).get("/.well-known/agent.json");
+    expect(res.status).toBe(200);
+  });
+
+  it("returns 403 for disallowed provider", async () => {
+    const config: OnboardingConfig = {
+      ...baseConfig,
+      allowedProviders: ["anthropic"],
+    };
+    const app = createApp(config);
+    const res = await request(app.callback())
+      .post("/agent/register")
+      .send(validBody);
+    expect(res.status).toBe(403);
+  });
+
+  it("returns 502 when webhook fails", async () => {
+    mockFetch.mockRejectedValueOnce(new Error("Connection refused"));
+    const app = createApp();
+    const res = await request(app.callback())
+      .post("/agent/register")
+      .send(validBody);
+    expect(res.status).toBe(502);
+  });
+});

--- a/packages/koa/src/agent-onboarding.ts
+++ b/packages/koa/src/agent-onboarding.ts
@@ -1,0 +1,60 @@
+import Router from "@koa/router";
+import type { Context, Next } from "koa";
+import type {
+  OnboardingConfig,
+  RegistrationRequest,
+} from "@agent-layer/core";
+import { createOnboardingHandler } from "@agent-layer/core";
+
+/**
+ * Koa adapter for agent-onboarding.
+ *
+ * Returns a Koa router with POST /agent/register and an authRequired() middleware
+ * that returns 401 for unauthenticated agent requests on non-exempt paths.
+ */
+export function agentOnboarding(config: OnboardingConfig) {
+  const handler = createOnboardingHandler(config);
+
+  function getClientIp(ctx: Context): string {
+    const forwarded = ctx.get("x-forwarded-for");
+    if (forwarded) return forwarded.split(",")[0].trim();
+    return ctx.ip ?? "unknown";
+  }
+
+  /** Returns a Koa Router with POST /agent/register. */
+  function registerRoute(): Router {
+    const router = new Router();
+
+    router.post("/agent/register", async (ctx: Context) => {
+      const body = (ctx.request as any).body as RegistrationRequest;
+      const ip = getClientIp(ctx);
+      const result = await handler.handleRegister(body, ip);
+      ctx.status = result.status;
+      ctx.body = result.body;
+    });
+
+    return router;
+  }
+
+  /** Middleware that returns 401 for unauthenticated requests on non-exempt paths. */
+  function authRequired() {
+    return async function authRequiredMiddleware(
+      ctx: Context,
+      next: Next,
+    ): Promise<void> {
+      const headers: Record<string, string | undefined> = {};
+      for (const [k, v] of Object.entries(ctx.headers)) {
+        headers[k] = Array.isArray(v) ? v[0] : v;
+      }
+
+      if (handler.shouldReturn401(ctx.path, headers)) {
+        ctx.status = 401;
+        ctx.body = handler.getAuthRequiredResponse();
+        return;
+      }
+      await next();
+    };
+  }
+
+  return { registerRoute, authRequired };
+}

--- a/packages/koa/src/index.ts
+++ b/packages/koa/src/index.ts
@@ -19,6 +19,7 @@ export { llmsTxtRoutes } from "./llms-txt.js";
 export { discoveryRoutes } from "./discovery.js";
 export { agentMeta } from "./agent-meta.js";
 export { agentAuth } from "./agent-auth.js";
+export { agentOnboarding } from "./agent-onboarding.js";
 export { agentAnalytics } from "./analytics.js";
 export type { AnalyticsConfig, AnalyticsInstance, AgentEvent } from "./analytics.js";
 export { apiKeyAuth, requireScope } from "./api-keys.js";

--- a/packages/strapi/tsconfig.json
+++ b/packages/strapi/tsconfig.json
@@ -15,5 +15,5 @@
     "outDir": "dist",
     "rootDir": "src"
   },
-  "exclude": ["node_modules", "dist", "**/*.test.ts"]
+  "exclude": ["node_modules", "dist", "**/*.test.ts", "tsup.config.ts"]
 }


### PR DESCRIPTION
## Daily Audit — March 30, 2026

### Changes
- **Export agentOnboarding** from express, fastify, hono, koa barrel indexes (were untracked/unexported)
- **Fix Koa body type** — `ctx.request.body` needed type assertion for koa-bodyparser
- **Fix strapi tsconfig** — exclude `tsup.config.ts` from rootDir check (TS6059)

### Results
- 994 tests passing (up from 954 — new onboarding adapter tests now included)
- TypeScript clean across all 8 packages
- No lint issues

Co-authored-by: Sylphie <sylphie@lightlayer.dev>